### PR TITLE
Super Smash Brothers

### DIFF
--- a/datasets/smash_data.js
+++ b/datasets/smash_data.js
@@ -22,7 +22,7 @@ const characters = [
     images: {
       large:'./images/characters/bayonetta.png',
       icon: './images/character_icons/bayonetta_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/bayonetta_head.png'
+      small_icon: './images/character_icons/small_character_icons/bayonetta_head.png'
     }
   },
   {
@@ -48,7 +48,7 @@ const characters = [
     images: {
       large:'./images/characters/bowser.png',
       icon: './images/character_icons/bowser_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/bowser_head.png'
+      small_icon: './images/character_icons/small_character_icons/bowser_head.png'
     }
   },
   {
@@ -74,7 +74,7 @@ const characters = [
     images: {
       large:'./images/characters/bowser_jr.png',
       icon: './images/character_icons/bowser_jr_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/bowser_jr_head.png'
+      small_icon: './images/character_icons/small_character_icons/bowser_jr_head.png'
     }
   },
   {
@@ -100,7 +100,7 @@ const characters = [
     images: {
       large:'./images/characters/captain_falcon.png',
       icon: './images/character_icons/captain_falcon_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/captain_falcon_head.png'
+      small_icon: './images/character_icons/small_character_icons/captain_falcon_head.png'
     }
   },
   {
@@ -126,7 +126,7 @@ const characters = [
     images: {
       large:'./images/characters/charizard.png',
       icon: './images/character_icons/charizard_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/charizard_head.png'
+      small_icon: './images/character_icons/small_character_icons/charizard_head.png'
     }
   },
   {
@@ -152,7 +152,7 @@ const characters = [
     images: {
       large:'./images/characters/cloud.png',
       icon: './images/character_icons/cloud_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/cloud_head.png'
+      small_icon: './images/character_icons/small_character_icons/cloud_head.png'
     }
   },
   {
@@ -178,7 +178,7 @@ const characters = [
     images: {
       large:'./images/characters/corrin.png',
       icon: './images/character_icons/corrin_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/corrin_head.png'
+      small_icon: './images/character_icons/small_character_icons/corrin_head.png'
     }
   },
   {
@@ -204,7 +204,7 @@ const characters = [
     images: {
       large:'./images/characters/dark_pit.png',
       icon: './images/character_icons/dark_pit_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/dark_pit_head.png'
+      small_icon: './images/character_icons/small_character_icons/dark_pit_head.png'
     }
   },
   {
@@ -230,7 +230,7 @@ const characters = [
     images: {
       large:'./images/characters/diddy_kong.png',
       icon: './images/character_icons/diddy_kong_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/diddy_kong_head.png'
+      small_icon: './images/character_icons/small_character_icons/diddy_kong_head.png'
     }
   },
   {
@@ -256,7 +256,7 @@ const characters = [
     images: {
       large:'./images/characters/donkey_kong.png',
       icon: './images/character_icons/donkey_kong_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/donkey_kong_head.png'
+      small_icon: './images/character_icons/small_character_icons/donkey_kong_head.png'
     }
   },
   {
@@ -282,7 +282,7 @@ const characters = [
     images: {
       large:'./images/characters/dr_mario.png',
       icon: './images/character_icons/dr_mario_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/dr_mario_head.png'
+      small_icon: './images/character_icons/small_character_icons/dr_mario_head.png'
     }
   },
   {
@@ -308,7 +308,7 @@ const characters = [
     images: {
       large:'./images/characters/duck_hunt.png',
       icon: './images/character_icons/duck_hunt_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/duck_hunt_head.png'
+      small_icon: './images/character_icons/small_character_icons/duck_hunt_head.png'
     }
   },
   {
@@ -334,7 +334,7 @@ const characters = [
     images: {
       large:'./images/characters/falco.png',
       icon: './images/character_icons/falco_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/falco_head.png'
+      small_icon: './images/character_icons/small_character_icons/falco_head.png'
     }
   },
   {
@@ -360,7 +360,7 @@ const characters = [
     images: {
       large:'./images/characters/fox.png',
       icon: './images/character_icons/fox_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/fox_head.png'
+      small_icon: './images/character_icons/small_character_icons/fox_head.png'
     }
   },
   {
@@ -386,7 +386,7 @@ const characters = [
     images: {
       large:'./images/characters/ganondorf.png',
       icon: './images/character_icons/ganondorf_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/ganondorf_head.png'
+      small_icon: './images/character_icons/small_character_icons/ganondorf_head.png'
     }
   },
   {
@@ -412,7 +412,7 @@ const characters = [
     images: {
       large:'./images/characters/greninja.png',
       icon: './images/character_icons/greninja_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/greninja_head.png'
+      small_icon: './images/character_icons/small_character_icons/greninja_head.png'
     }
   },
   {
@@ -438,7 +438,7 @@ const characters = [
     images: {
       large:'./images/characters/ike.png',
       icon: './images/character_icons/ike_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/ike_head.png'
+      small_icon: './images/character_icons/small_character_icons/ike_head.png'
     }
   },
   {
@@ -464,7 +464,7 @@ const characters = [
     images: {
       large:'./images/characters/jigglypuff.png',
       icon: './images/character_icons/jigglypuff_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/jigglypuff_head.png'
+      small_icon: './images/character_icons/small_character_icons/jigglypuff_head.png'
     }
   },
   {
@@ -490,7 +490,7 @@ const characters = [
     images: {
       large:'./images/characters/king_dedede.png',
       icon: './images/character_icons/king_dedede_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/king_dedede_head.png'
+      small_icon: './images/character_icons/small_character_icons/king_dedede_head.png'
     }
   },
   {
@@ -516,7 +516,7 @@ const characters = [
     images: {
       large:'./images/characters/kirby.png',
       icon: './images/character_icons/kirby_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/kirby_head.png'
+      small_icon: './images/character_icons/small_character_icons/kirby_head.png'
     }
   },
   {
@@ -542,7 +542,7 @@ const characters = [
     images: {
       large:'./images/characters/link.png',
       icon: './images/character_icons/link_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/link_head.png'
+      small_icon: './images/character_icons/small_character_icons/link_head.png'
     }
   },
   {
@@ -568,7 +568,7 @@ const characters = [
     images: {
       large:'./images/characters/little_mac.png',
       icon: './images/character_icons/little_mac_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/little_mac_head.png'
+      small_icon: './images/character_icons/small_character_icons/little_mac_head.png'
     }
   },
   {
@@ -594,7 +594,7 @@ const characters = [
     images: {
       large:'./images/characters/lucario.png',
       icon: './images/character_icons/lucario_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/lucario_head.png'
+      small_icon: './images/character_icons/small_character_icons/lucario_head.png'
     }
   },
   {
@@ -620,7 +620,7 @@ const characters = [
     images: {
       large:'./images/characters/lucas.png',
       icon: './images/character_icons/lucas_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/lucas_head.png'
+      small_icon: './images/character_icons/small_character_icons/lucas_head.png'
     }
   },
   {
@@ -646,7 +646,7 @@ const characters = [
     images: {
       large:'./images/characters/lucina.png',
       icon: './images/character_icons/lucina_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/lucina_head.png'
+      small_icon: './images/character_icons/small_character_icons/lucina_head.png'
     }
   },
   {
@@ -672,7 +672,7 @@ const characters = [
     images: {
       large:'./images/characters/luigi.png',
       icon: './images/character_icons/luigi_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/luigi_head.png'
+      small_icon: './images/character_icons/small_character_icons/luigi_head.png'
     }
   },
   {
@@ -698,7 +698,7 @@ const characters = [
     images: {
       large:'./images/characters/mario.png',
       icon: './images/character_icons/mario_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/mario_head.png'
+      small_icon: './images/character_icons/small_character_icons/mario_head.png'
     }
   },
   {
@@ -724,7 +724,7 @@ const characters = [
     images: {
       large:'./images/characters/marth.png',
       icon: './images/character_icons/marth_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/marth_head.png'
+      small_icon: './images/character_icons/small_character_icons/marth_head.png'
     }
   },
   {
@@ -750,7 +750,7 @@ const characters = [
     images: {
       large:'./images/characters/mega_man.png',
       icon: './images/character_icons/mega_man_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/mega_man_head.png'
+      small_icon: './images/character_icons/small_character_icons/mega_man_head.png'
     }
   },
   {
@@ -776,7 +776,7 @@ const characters = [
     images: {
       large:'./images/characters/meta_knight.png',
       icon: './images/character_icons/meta_knight_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/meta_knight_head.png'
+      small_icon: './images/character_icons/small_character_icons/meta_knight_head.png'
     }
   },
   {
@@ -802,7 +802,7 @@ const characters = [
     images: {
       large:'./images/characters/mewtwo.png',
       icon: './images/character_icons/mewtwo_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/mewtwo_head.png'
+      small_icon: './images/character_icons/small_character_icons/mewtwo_head.png'
     }
   },
   {
@@ -828,7 +828,7 @@ const characters = [
     images: {
       large:'./images/characters/mii_brawler.png',
       icon: './images/character_icons/smash_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/mii_brawler_head.png'
+      small_icon: './images/character_icons/small_character_icons/mii_brawler_head.png'
     }
   },
   {
@@ -854,7 +854,7 @@ const characters = [
     images: {
       large:'./images/characters/mii_gunner.png',
       icon: './images/character_icons/smash_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/mii_gunner_head.png'
+      small_icon: './images/character_icons/small_character_icons/mii_gunner_head.png'
     }
   },
   {
@@ -880,7 +880,7 @@ const characters = [
     images: {
       large:'./images/characters/mii_sword_fighter.png',
       icon: './images/character_icons/smash_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/mii_sword_fighter_head.png'
+      small_icon: './images/character_icons/small_character_icons/mii_sword_fighter_head.png'
     }
   },
   {
@@ -906,7 +906,7 @@ const characters = [
     images: {
       large:'./images/characters/mr_game_and_watch.png',
       icon: './images/character_icons/mr_game_and_watch_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/mr_game_and_watch_head.png'
+      small_icon: './images/character_icons/small_character_icons/mr_game_and_watch_head.png'
     }
   },
   {
@@ -932,7 +932,7 @@ const characters = [
     images: {
       large:'./images/characters/ness.png',
       icon: './images/character_icons/ness_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/ness_head.png'
+      small_icon: './images/character_icons/small_character_icons/ness_head.png'
     }
   },
   {
@@ -958,7 +958,7 @@ const characters = [
     images: {
       large:'./images/characters/olimar.png',
       icon: './images/character_icons/olimar_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/olimar_head.png'
+      small_icon: './images/character_icons/small_character_icons/olimar_head.png'
     }
   },
   {
@@ -984,7 +984,7 @@ const characters = [
     images: {
       large:'./images/characters/pac_man.png',
       icon: './images/character_icons/pac_man_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/pac_man_head.png'
+      small_icon: './images/character_icons/small_character_icons/pac_man_head.png'
     }
   },
   {
@@ -1010,7 +1010,7 @@ const characters = [
     images: {
       large:'./images/characters/palutena.png',
       icon: './images/character_icons/palutena_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/palutena_head.png'
+      small_icon: './images/character_icons/small_character_icons/palutena_head.png'
     }
   },
   {
@@ -1036,7 +1036,7 @@ const characters = [
     images: {
       large:'./images/characters/peach.png',
       icon: './images/character_icons/peach_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/peach_head.png'
+      small_icon: './images/character_icons/small_character_icons/peach_head.png'
     }
   },
   {
@@ -1062,7 +1062,7 @@ const characters = [
     images: {
       large:'./images/characters/pikachu.png',
       icon: './images/character_icons/pikachu_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/pikachu_head.png'
+      small_icon: './images/character_icons/small_character_icons/pikachu_head.png'
     }
   },
   {
@@ -1088,7 +1088,7 @@ const characters = [
     images: {
       large:'./images/characters/pit.png',
       icon: './images/character_icons/pit_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/pit_head.png'
+      small_icon: './images/character_icons/small_character_icons/pit_head.png'
     }
   },
   {
@@ -1114,7 +1114,7 @@ const characters = [
     images: {
       large:'./images/characters/rob.png',
       icon: './images/character_icons/rob_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/rob_head.png'
+      small_icon: './images/character_icons/small_character_icons/rob_head.png'
     }
   },
   {
@@ -1140,7 +1140,7 @@ const characters = [
     images: {
       large:'./images/characters/robin.png',
       icon: './images/character_icons/robin_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/robin_head.png'
+      small_icon: './images/character_icons/small_character_icons/robin_head.png'
     }
   },
   {
@@ -1166,7 +1166,7 @@ const characters = [
     images: {
       large:'./images/characters/rosalina.png',
       icon: './images/character_icons/rosalina_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/rosalina_head.png'
+      small_icon: './images/character_icons/small_character_icons/rosalina_head.png'
     }
   },
   {
@@ -1192,7 +1192,7 @@ const characters = [
     images: {
       large:'./images/characters/roy.png',
       icon: './images/character_icons/roy_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/roy_head.png'
+      small_icon: './images/character_icons/small_character_icons/roy_head.png'
     }
   },
   {
@@ -1218,7 +1218,7 @@ const characters = [
     images: {
       large:'./images/characters/ryu.png',
       icon: './images/character_icons/ryu_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/ryu_head.png'
+      small_icon: './images/character_icons/small_character_icons/ryu_head.png'
     }
   },
   {
@@ -1244,7 +1244,7 @@ const characters = [
     images: {
       large:'./images/characters/samus.png',
       icon: './images/character_icons/samus_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/samus_head.png'
+      small_icon: './images/character_icons/small_character_icons/samus_head.png'
     }
   },
   {
@@ -1270,7 +1270,7 @@ const characters = [
     images: {
       large:'./images/characters/sheik.png',
       icon: './images/character_icons/sheik_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/sheik_head.png'
+      small_icon: './images/character_icons/small_character_icons/sheik_head.png'
     }
   },
   {
@@ -1296,7 +1296,7 @@ const characters = [
     images: {
       large:'./images/characters/shulk.png',
       icon: './images/character_icons/shulk_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/shulk_head.png'
+      small_icon: './images/character_icons/small_character_icons/shulk_head.png'
     }
   },
   {
@@ -1322,7 +1322,7 @@ const characters = [
     images: {
       large:'./images/characters/sonic.png',
       icon: './images/character_icons/sonic_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/sonic_head.png'
+      small_icon: './images/character_icons/small_character_icons/sonic_head.png'
     }
   },
   {
@@ -1348,7 +1348,7 @@ const characters = [
     images: {
       large:'./images/characters/toon_link.png',
       icon: './images/character_icons/toon_link_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/toon_link_head.png'
+      small_icon: './images/character_icons/small_character_icons/toon_link_head.png'
     }
   },
   {
@@ -1374,7 +1374,7 @@ const characters = [
     images: {
       large:'./images/characters/villager.png',
       icon: './images/character_icons/villager_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/villager_head.png'
+      small_icon: './images/character_icons/small_character_icons/villager_head.png'
     }
   },
   {
@@ -1400,7 +1400,7 @@ const characters = [
     images: {
       large:'./images/characters/wario.png',
       icon: './images/character_icons/wario_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/wario_head.png'
+      small_icon: './images/character_icons/small_character_icons/wario_head.png'
     }
   },
   {
@@ -1426,7 +1426,7 @@ const characters = [
     images: {
       large:'./images/characters/wii_fit_trainer.png',
       icon: './images/character_icons/wii_fit_trainer_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/wii_fit_trainer_head.png'
+      small_icon: './images/character_icons/small_character_icons/wii_fit_trainer_head.png'
     }
   },
   {
@@ -1452,7 +1452,7 @@ const characters = [
     images: {
       large:'./images/characters/yoshi.png',
       icon: './images/character_icons/yoshi_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/yoshi_head.png'
+      small_icon: './images/character_icons/small_character_icons/yoshi_head.png'
     }
   },
   {
@@ -1478,7 +1478,7 @@ const characters = [
     images: {
       large:'./images/characters/zelda.png',
       icon: './images/character_icons/zelda_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/zelda_head.png'
+      small_icon: './images/character_icons/small_character_icons/zelda_head.png'
     }
   },
   {
@@ -1504,7 +1504,7 @@ const characters = [
     images: {
       large:'./images/characters/zero_suit_samus.png',
       icon: './images/character_icons/zero_suit_samus_icon.png',
-      small_icon: './images/charcter_icons/small_character_icons/zero_suit_samus_head.png'
+      small_icon: './images/character_icons/small_character_icons/zero_suit_samus_head.png'
     }
   }
 ];

--- a/datasets/smash_data.js
+++ b/datasets/smash_data.js
@@ -1,0 +1,2544 @@
+const characters = [
+  {
+    name: 'Bayonetta',
+    counter: true,
+    tier: {tier: 'S', rank: 1},
+    world_stats: {wins: 7801, losses: 6353},
+    universe: universes.bayonetta,
+    past_smash_games: [],
+    strongest_smash: {attack: 'Up Smash', damage: 17},
+    jump_height: 39,
+    weight: {class: 'Feather Weight', weight_value: 84},
+    speeds: {
+      initial_dash: 1.7,
+      run_speed: 3.5,
+      air_speed: .97,
+      fall_speed: 1.77,
+      fast_fall_speed: 2.83,
+    },
+    pros: ['Great Combos', 'Witch time', 'Can kill early', 'Great recovery with double jump'],
+    cons: ['Her projectile has a hard time hitting smaller characters', 'Slow run', 'Everyone will hate you for playing her'],
+    smash_wiki: 'https://ssbworld.com/characters/Bayonetta_(SSB4)',
+    images: {
+      large:'./images/characters/bayonetta.png',
+      icon: './images/character_icons/bayonetta_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/bayonetta_head.png'
+    }
+  },
+  {
+    name: 'Bowser',
+    counter: false,
+    tier: {tier: 'C', rank: 24},
+    world_stats: {wins: 1458, losses: 1508},
+    universe: universe.mario,
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee', 'Smash Bros. (64)'],
+    strongest_smash: {attack: 'Forward Smash', damage: 23},
+    jump_height: 33,
+    weight: {class: 'Super Heavy Weight', weight_value: 130},
+    speeds: {
+      initial_dash: 1,
+      run_speed: 1.79,
+      air_speed: 1,
+      fall_speed: 1.39,
+      fast_fall_speed: 2.22,
+    },
+    pros: ['Very powerful smash attacks', 'Very heavy', 'Great dash speed', 'Good range on attacks'],
+    cons: ['Has a tough time getting past zoning', 'Combo\'d easily', 'Size makes big target for projectiles', 'Somewhat poor recovery'],
+    smash_wiki: 'https://ssbworld.com/characters/Bowser_(SSB4)',
+    images: {
+      large:'./images/characters/bowser.png',
+      icon: './images/character_icons/bowser_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/bowser_head.png'
+    }
+  },
+  {
+    name: 'Bowser Jr.',
+    counter: false,
+    tier: {tier: 'F', rank: 48},
+    world_stats: {wins: 734, losses: 800},
+    universe: universe.mario,
+    past_smash_games: [],
+    strongest_smash: {attack: 'Down Smash', damage: 18},
+    jump_height: 34.4,
+    weight: {class: 'Heavy Weight', weight_value: 108},
+    speeds: {
+      initial_dash: 1.6,
+      run_speed: 1.42,
+      air_speed: 1.08,
+      fall_speed: 1.65,
+      fast_fall_speed: 2.64,
+    },
+    pros: ['Has 2 hurtboxes, takes less damages when his clown car is hit', 'Powerful smash attacks', 'Side special can be cancelled into other aerials'],
+    cons: ['Takes extra damage when Boswer Jr. himself is attacked', 'Smashes require hard reads', 'Slow moves'],
+    smash_wiki: 'https://ssbworld.com/characters/Bowser_Jr._(SSB4)',
+    images: {
+      large:'./images/characters/bowser_jr.png',
+      icon: './images/character_icons/bowser_jr_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/bowser_jr_head.png'
+    }
+  },
+  {
+    name: 'Captain Falcon',
+    counter: false,
+    tier: {tier: 'B', rank: 19},
+    world_stats: {wins: 3922, losses: 3715},
+    universe: universes.f_zero,
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee', 'Smash Bros. (64)'],
+    strongest_smash: {attack: 'Forward Smash', damage: 20},
+    jump_height: 37.3,
+    weight: {class: 'Heavy Weight', weight_value: 104},
+    speeds: {
+      initial_dash: 1.7,
+      run_speed: 2.32,
+      air_speed: 1.1,
+      fall_speed: 1.84,
+      fast_fall_speed: 2.94,
+    },
+    pros: ['Amazing combo and damage output potential', 'Many good kill options', 'One of the best dash grabs in game', 'Fast speed and good weight'],
+    cons: ['Not many spacing options', 'Tall hurtbox', 'Standing grab has little range', 'Not great when being zoned out by projectiles'],
+    smash_wiki: 'https://ssbworld.com/characters/Captain_Falcon_(SSB4)',
+    images: {
+      large:'./images/characters/captain_falcon.png',
+      icon: './images/character_icons/captain_falcon_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/captain_falcon_head.png'
+    }
+  },
+  {
+    name: 'Charizard',
+    counter: false,
+    tier: {tier: 'E', rank: 43},
+    world_stats: {wins: 957, losses: 883},
+    universe: universes.pokemon,
+    past_smash_games: ['Smash Bros. Brawl'],
+    strongest_smash: {attack: 'Forward Smash', damage: 17},
+    jump_height: 32,
+    weight: {class: 'Super Heavy Weight', weight_value: 116},
+    speeds: {
+      initial_dash: 1,
+      run_speed: 2,
+      air_speed: .92,
+      fall_speed: 1.4,
+      fast_fall_speed: 2.24,
+    },
+    pros: ['Very heavy damage output character', 'Great at edge-guarding', 'Up throw is a strong kill throw', 'Amazing grab range'],
+    cons: ['Large hurtbox - vulnerable to combos and projectiles', 'Slow air movement', 'Heavy character', 'Rock smash beaten by swords'],
+    smash_wiki: 'https://ssbworld.com/characters/Charizard_(SSB4)',
+    images: {
+      large:'./images/characters/charizard.png',
+      icon: './images/character_icons/charizard_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/charizard_head.png'
+    }
+  },
+  {
+    name: 'Cloud',
+    counter: false,
+    tier: {tier: 'S', rank: 2},
+    world_stats: {wins: 7088, losses: 6430},
+    universe: universes.final_fantasy,
+    past_smash_games: [],
+    strongest_smash: {attack: 'Forward Smash (3-hit combo)', damage: 20},
+    jump_height: 32.5,
+    weight: {class: 'Heavy Weight', weight_value: 100},
+    speeds: {
+      initial_dash: 1.8,
+      run_speed: 1.97,
+      air_speed: 1.1,
+      fall_speed: 1.68,
+      fast_fall_speed: 2.69,
+    },
+    pros: ['Large, disjointed hitbox', 'Amazing range on attacks', 'Several kill options', 'Fairly good combo ability'],
+    cons: ['Short grab range', 'Difficulty approaching, especially against projectile weilders', 'Subpar recovery', 'Kill moves can be difficult to land'],
+    smash_wiki: 'https://ssbworld.com/characters/Cloud_(SSB4)',
+    images: {
+      large:'./images/characters/cloud.png',
+      icon: './images/character_icons/cloud_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/cloud_head.png'
+    }
+  },
+  {
+    name: 'Corrin',
+    counter: true,
+    tier: {tier: 'B', rank: 13},
+    world_stats: {wins: 3485, losses: 3505},
+    universe: universes.fire_emblem,
+    past_smash_games: [],
+    strongest_smash: {attack: 'Forward Smash (tip of sword))', damage: 16},
+    jump_height: 33,
+    weight: {class: 'Middle Weight', weight_value: 98},
+    speeds: {
+      initial_dash: 1.8,
+      run_speed: 1.45,
+      air_speed: .97,
+      fall_speed: 1.65,
+      fast_fall_speed: 2.64,
+    },
+    pros: ['Incredible pillar combos', 'Great spacing capabilities', 'Good recovery priority (recovery move beats out out other high priority moves)'],
+    cons: ['Recovery distance is average', 'Has slow run', 'Doesn\'t have great landing options', 'Approach options are easily punished'],
+    smash_wiki: 'https://ssbworld.com/characters/Corrin_(SSB4)',
+    images: {
+      large:'./images/characters/corrin.png',
+      icon: './images/character_icons/corrin_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/corrin_head.png'
+    }
+  },
+  {
+    name: 'Dark Pit',
+    counter: false,
+    tier: {tier: 'D', rank: 33},
+    world_stats: {wins: 220, losses: 303},
+    universe: universes.kid_icarus,
+    past_smash_games: [],
+    strongest_smash: {attack: 'Forward Smash (2-hit combo)', damage: 15},
+    jump_height: 31,
+    weight: {class: 'Middle Weight', weight_value: 96},
+    speeds: {
+      initial_dash: 1.5,
+      run_speed: 1.66,
+      air_speed: .89,
+      fall_speed: 1.48,
+      fast_fall_speed: 2.37,
+    },
+    pros: ['Great recovery', 'More powerful arrows than regular Pit', 'Electroshock arm can kill very early', 'Has cooler voice than Pit'],
+    cons: ['Arrows are slower and easity to dodge than regular Pit', 'Laggy aerials', 'Arrows have less range than regular Pit'],
+    smash_wiki: 'https://ssbworld.com/characters/Dark_Pit_(SSB4)',
+    images: {
+      large:'./images/characters/dark_pit.png',
+      icon: './images/character_icons/dark_pit_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/dark_pit_head.png'
+    }
+  },
+  {
+    name: 'Diddy Kong',
+    counter: false,
+    tier: {tier: 'S', rank: 3},
+    world_stats: {wins: 7451, losses: 5815},
+    universe: universes.donkey_kong,
+    past_smash_games: ['Smash Bros. Brawl'],
+    strongest_smash: {attack: 'Forward Smash (2-hit combo)', damage: 16},
+    jump_height: 41.2,
+    weight: {class: 'Middle Weight', weight_value: 93},
+    speeds: {
+      initial_dash: 1.7,
+      run_speed: 1.82,
+      air_speed: .88,
+      fall_speed: 1.75,
+      fast_fall_speed: 2.8,
+    },
+    pros: ['Excellent combo potential', 'Powerful and versatile projectiles', 'Very fast', 'Good horizontal and vertical recovery options', 'Insane hitboxes'],
+    cons: ['Recovery easy to take advantage of', 'Bananas can be used aginst him', 'Whiffed side special has a lot of landing lag'],
+    smash_wiki: 'https://ssbworld.com/characters/Diddy_Kong_(SSB4)',
+    images: {
+      large:'./images/characters/diddy_kong.png',
+      icon: './images/character_icons/diddy_kong_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/diddy_kong_head.png'
+    }
+  },
+  {
+    name: 'Donkey Kong',
+    counter: false,
+    tier: {tier: 'C', rank: 22},
+    world_stats: {wins: 2180, losses: 2103},
+    universe: universes.donkey_kong,
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee', 'Smash Bros. (64)'],
+    strongest_smash: {attack: 'Giant Punch (Neutral Special fully charged)', damage: 28},
+    jump_height: 34,
+    weight: {class: 'Super Heavy Weight', weight_value: 122},
+    speeds: {
+      initial_dash: 1.6,
+      run_speed: 1.7,
+      air_speed: 1.15,
+      fall_speed: 1.63,
+      fast_fall_speed: 2.61,
+    },
+    pros: ['Powerful and quick smash attacks', 'Can kill early', 'Very heavy and hard to kill'],
+    cons: ['Can be combo\'d easily', 'Big target', 'Few approach options', 'Has difficulty with zoners'],
+    smash_wiki: 'https://ssbworld.com/characters/Donkey_Kong_(SSB4)',
+    images: {
+      large:'./images/characters/donkey_kong.png',
+      icon: './images/character_icons/donkey_kong_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/donkey_kong_head.png'
+    }
+  },
+  {
+    name: 'Dr. Mario',
+    counter: false,
+    tier: {tier: 'F', rank: 49},
+    world_stats: {wins: 288, losses: 372},
+    universe: universe.mario,
+    past_smash_games: ['Smash Bros. Melee'],
+    strongest_smash: {attack: 'Forward Smash', damage: 20},
+    jump_height: 36.33,
+    weight: {class: 'Middle Weight', weight_value: 98},
+    speeds: {
+      initial_dash: 1.33,
+      run_speed: 1.33,
+      air_speed: .93,
+      fall_speed: 1.5,
+      fast_fall_speed: 2.4,
+    },
+    pros: ['Good kill power off relatively safe moves', 'More range with pills than Mario', 'Great out of shield options', 'Above average edge gaurding'],
+    cons: ['Poor recovery', 'Slow movement on ground and in air', 'Poor range', 'Struggles to approach'],
+    smash_wiki: 'https://ssbworld.com/characters/Dr._Mario_(SSB4)',
+    images: {
+      large:'./images/characters/dr_mario.png',
+      icon: './images/character_icons/dr_mario_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/dr_mario_head.png'
+    }
+  },
+  {
+    name: 'Duck Hunt',
+    counter: false,
+    tier: {tier: 'D', rank: 30},
+    world_stats: {wins: 752, losses: 906},
+    universe: universes.duck_hunt,
+    past_smash_games: [],
+    strongest_smash: {attack: 'Forward Smash (3-hit combo)', damage: 17},
+    jump_height: 34,
+    weight: {class: 'Middle Weight', weight_value: 91},
+    speeds: {
+      initial_dash: 1.55,
+      run_speed: 1.63,
+      air_speed: 1.1,
+      fall_speed: 1.65,
+      fast_fall_speed: 2.64,
+    },
+    pros: ['Very strong zoning', 'Has many traps and special moves', 'Can rack up damage fast'],
+    cons: ['Very light', 'Has a hard time killing', 'Difficult to setup traps when being rushed'],
+    smash_wiki: 'https://ssbworld.com/characters/Duck_Hunt_(SSB4)',
+    images: {
+      large:'./images/characters/duck_hunt.png',
+      icon: './images/character_icons/duck_hunt_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/duck_hunt_head.png'
+    }
+  },
+  {
+    name: 'Falco',
+    counter: false,
+    tier: {tier: 'F', rank: 47},
+    world_stats: {wins: 802, losses: 916},
+    universe: universes.star_fox,
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee'],
+    strongest_smash: {attack: 'Down Smash', damage: 15},
+    jump_height: 50.51,
+    weight: {class: 'Feather Weight', weight_value: 82},
+    speeds: {
+      initial_dash: 1.9,
+      run_speed: 1.47,
+      air_speed: .93,
+      fall_speed: 1.8,
+      fast_fall_speed: 2.88,
+    },
+    pros: ['Long range reflector that does damages', 'Knockback on projectile', 'Great spacing tools'],
+    cons: ['Light weight', 'Somewhat poor recovery', 'Can be hard to get the KO'],
+    smash_wiki: 'https://ssbworld.com/characters/Falco_(SSB4)',
+    images: {
+      large:'./images/characters/falco.png',
+      icon: './images/character_icons/falco_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/falco_head.png'
+    }
+  },
+  {
+    name: 'Fox',
+    counter: false,
+    tier: {tier: 'A', rank: 7},
+    world_stats: {wins: 5632, losses: 5515},
+    universe: universes.star_fox,
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee', 'Smash Bros. (64)'],
+    strongest_smash: {attack: 'Up Smash', damage: 16},
+    jump_height: 35,
+    weight: {class: 'Feather Weight', weight_value: 79},
+    speeds: {
+      initial_dash: 2.4,
+      run_speed: 2.18,
+      air_speed: .96,
+      fall_speed: 2.05,
+      fast_fall_speed: 3.28,
+    },
+    pros: ['Extremely fast', 'Quick smash attacks', 'Good combos and rush down'],
+    cons: ['Light weight', 'Somewhat predictable recovery', 'Can be hard to get the KO'],
+    smash_wiki: 'https://ssbworld.com/characters/Fox_(SSB4)',
+    images: {
+      large:'./images/characters/fox.png',
+      icon: './images/character_icons/fox_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/fox_head.png'
+    }
+  },
+  {
+    name: 'Ganondorf',
+    counter: false,
+    tier: {tier: 'G', rank: 53},
+    world_stats: {wins: 1437, losses: 1396},
+    universe: universes.legend_of_zelda,
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee'],
+    strongest_smash: {attack: 'Up Tilt', damage: 28},
+    jump_height: 25.49,
+    weight: {class: 'Super Heavy Weight', weight_value: 113},
+    speeds: {
+      initial_dash: 1.3,
+      run_speed: 1.22,
+      air_speed: .79,
+      fall_speed: 1.65,
+      fast_fall_speed: 2.64,
+    },
+    pros: ['Extremely good edge guarder', 'Good combo ability', 'Heavy and powerful', 'Great range'],
+    cons: ['Slow and punished easily', 'Huge hurtbox', 'Easily rushed down', 'Slow gimpable recovery'],
+    smash_wiki: 'https://ssbworld.com/characters/Ganondorf_(SSB4)',
+    images: {
+      large:'./images/characters/ganondorf.png',
+      icon: './images/character_icons/ganondorf_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/ganondorf_head.png'
+    }
+  },
+  {
+    name: 'Greninja',
+    counter: true,
+    tier: {tier: 'C', rank: 26},
+    world_stats: {wins: 2115, losses: 2090},
+    universe: universes.pokemon,
+    past_smash_games: [],
+    strongest_smash: {attack: 'Up Smash (2-hit combo)', damage: 19},
+    jump_height: 46,
+    weight: {class: 'Middle Weight', weight_value: 94},
+    speeds: {
+      initial_dash: 1.6,
+      run_speed: 2.08,
+      air_speed: 1.18,
+      fall_speed: 1.85,
+      fast_fall_speed: 2.96,
+    },
+    pros: ['One of the best recoveries in game', 'Mobility is among the best', 'Great combo potential', 'Good range on attacks'],
+    cons: ['Poor options out of shield', 'Mediocre options for approaching', 'Terrible standing grab'],
+    smash_wiki: 'https://ssbworld.com/characters/Greninja_(SSB4)',
+    images: {
+      large:'./images/characters/greninja.png',
+      icon: './images/character_icons/greninja_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/greninja_head.png'
+    }
+  },
+  {
+    name: 'Ike',
+    counter: true,
+    tier: {tier: 'E', rank: 40},
+    world_stats: {wins: 1576, losses: 1528},
+    universe: universes.fire_emblem,
+    past_smash_games: ['Smash Bros. Brawl'],
+    strongest_smash: {attack: 'Eruption (Neutral Special fully charged)', damage: 35},
+    jump_height: 29,
+    weight: {class: 'Heavy Weight', weight_value: 107},
+    speeds: {
+      initial_dash: 1.5,
+      run_speed: 1.5,
+      air_speed: 1.08,
+      fall_speed: 1.65,
+      fast_fall_speed: 2.64,
+    },
+    pros: ['Attack inflict high damage and knockback', 'Good range', 'Eruption is a deadly edge guarding tool', 'Heaviness prolongs survivability'],
+    cons: ['Attacks are generally slow', 'Recovery is linear and predictable', 'Susceptible to combos'],
+    smash_wiki: 'https://ssbworld.com/characters/Ike_(SSB4)',
+    images: {
+      large:'./images/characters/ike.png',
+      icon: './images/character_icons/ike_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/ike_head.png'
+    }
+  },
+  {
+    name: 'Jigglypuff',
+    counter: false,
+    tier: {tier: 'G', rank: 55},
+    world_stats: {wins: 364, losses: 504},
+    universe: universes.pokemon,
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee', 'Smash Bros. (64)'],
+    strongest_smash: {attack: 'Rest (Down Special w/ Flower effect)', damage: 39},
+    jump_height: 19.78,
+    weight: {class: 'Balloon Weight', weight_value: 68},
+    speeds: {
+      initial_dash: 1.4,
+      run_speed: 1.16,
+      air_speed: 1.27,
+      fall_speed: .98,
+      fast_fall_speed: 1.57,
+    },
+    pros: ['Rest', 'Throws do ~12% damage', 'Best aerial game of cast', 'Recovery covers a lot of distance'],
+    cons: ['Slow gound speed', 'No up B recovery', 'Easy to edge guard'],
+    smash_wiki: 'https://ssbworld.com/characters/Jigglypuff_(SSB4)',
+    images: {
+      large:'./images/characters/jigglypuff.png',
+      icon: './images/character_icons/jigglypuff_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/jigglypuff_head.png'
+    }
+  },
+  {
+    name: 'King Dedede',
+    counter: false,
+    tier: {tier: 'G', rank: 52},
+    world_stats: {wins: 731, losses: 798},
+    universe: universes.kirby,
+    past_smash_games: ['Smash Bros. Brawl'],
+    strongest_smash: {attack: 'Jet Hammer (Down Special fully charged)', damage: 38},
+    jump_height: 32.85,
+    weight: {class: 'Super Heavy Weight', weight_value: 119},
+    speeds: {
+      initial_dash: 1.4,
+      run_speed: 1.36,
+      air_speed: .63,
+      fall_speed: 1.95,
+      fast_fall_speed: 3.12,
+    },
+    pros: ['Huge damage and knockback', 'One of the best recoveries in game', 'Great spot dodge', 'Hammer gives great range on attacks'],
+    cons: ['Can be combo\'d easily', 'Difficulty approaching', 'Can be rushed down by faster characters'],
+    smash_wiki: 'https://ssbworld.com/characters/King_Dedede_(SSB4)',
+    images: {
+      large:'./images/characters/king_dedede.png',
+      icon: './images/character_icons/king_dedede_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/king_dedede_head.png'
+    }
+  },
+  {
+    name: 'Kirby',
+    counter: false,
+    tier: {tier: 'F', rank: 50},
+    world_stats: {wins: 678, losses: 710},
+    universe: universes.kirby,
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee', 'Smash Bros. (64)'],
+    strongest_smash: {attack: 'Hammer Flip (Side Special fully charged)', damage: 35},
+    jump_height: 25.37,
+    weight: {class: 'Feather Weight', weight_value: 79},
+    speeds: {
+      initial_dash: 1.5,
+      run_speed: 1.57,
+      air_speed: .8,
+      fall_speed: 1.23,
+      fast_fall_speed: 1.97,
+    },
+    pros: ['Can crouch very low and duck under attacks', 'Great long distance recovery', 'Can copy abilities of opponents', 'Decent combo strings'],
+    cons: ['3rd lighest character', 'Low range', 'Poor mobility on ground and in air', 'Below average KO power'],
+    smash_wiki: 'https://ssbworld.com/characters/Kirby_(SSB4)',
+    images: {
+      large:'./images/characters/kirby.png',
+      icon: './images/character_icons/kirby_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/kirby_head.png'
+    }
+  },
+  {
+    name: 'Link',
+    counter: false,
+    tier: {tier: 'D', rank: 31},
+    world_stats: {wins: 1151, losses: 1550},
+    universe: universes.legend_of_zelda,
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee', 'Smash Bros. (64)'],
+    strongest_smash: {attack: 'Down Smash (1st hit 17% in front, 2nd hit 12% behind)', damage: 29},
+    jump_height: 27.8,
+    weight: {class: 'Heavy Weight', weight_value: 104},
+    speeds: {
+      initial_dash: 1.3,
+      run_speed: 1.39,
+      air_speed: .88,
+      fall_speed: 1.6,
+      fast_fall_speed: 3.04,
+    },
+    pros: ['Great zoning abilities', 'Strong KO moves', 'Great range', 'Punishes air dodges well'],
+    cons: ['Lacks reliable kill move', 'Slow', 'Can be combo\'d easily', 'Has many bad matchups'],
+    smash_wiki: 'https://ssbworld.com/characters/Link_(SSB4)',
+    images: {
+      large:'./images/characters/link.png',
+      icon: './images/character_icons/link_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/link_head.png'
+    }
+  },
+  {
+    name: 'Little Mac',
+    counter: true,
+    tier: {tier: 'E', rank: 44},
+    world_stats: {wins: 1647, losses: 1801},
+    universe: universes.punch_out,
+    past_smash_games: [],
+    strongest_smash: {attack: 'Straight Lunge (Neutral Special fully charged)', damage: 35},
+    jump_height: 26,
+    weight: {class: 'Feather Weight', weight_value: 82},
+    speeds: {
+      initial_dash: 2.05,
+      run_speed: 2.24,
+      air_speed: 1,
+      fall_speed: 1.8,
+      fast_fall_speed: 2.88,
+    },
+    pros: ['Amazing tilts, jab, and smashes', 'Can deal massive damage quickly', 'Relatively small hurtbox'],
+    cons: ['Poor aerials', 'Poor recovery', 'Many very difficult matchups'],
+    smash_wiki: 'https://ssbworld.com/characters/Little_Mac_(SSB4)',
+    images: {
+      large:'./images/characters/little_mac.png',
+      icon: './images/character_icons/little_mac_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/little_mac_head.png'
+    }
+  },
+  {
+    name: 'Lucario',
+    counter: true,
+    tier: {tier: 'B', rank: 17},
+    world_stats: {wins: 1170, losses: 1292},
+    universe: universes.pokemon,
+    past_smash_games: ['Smash Bros. Brawl'],
+    strongest_smash: {attack: 'Aura Sphere', damage: 17},
+    jump_height: 37.62,
+    weight: {class: 'Heavy Weight', weight_value: 99},
+    speeds: {
+      initial_dash: 1.8,
+      run_speed: 1.55,
+      air_speed: 1.09,
+      fall_speed: 1.68,
+      fast_fall_speed: 2.69,
+    },
+    pros: ['Aura Sphere combined with rage gives incredible knockback', 'Very good aerial attacks', 'Fast grabs and good throws'],
+    cons: ['Easily punished', 'More inclined for a defensive game', 'Slow smash attacks', 'Doesn\'t have great combos'],
+    smash_wiki: 'https://ssbworld.com/characters/Lucario_(SSB4)',
+    images: {
+      large:'./images/characters/lucario.png',
+      icon: './images/character_icons/lucario_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/lucario_head.png'
+    }
+  },
+  {
+    name: 'Lucas',
+    counter: false,
+    tier: {tier: 'C', rank: 29},
+    world_stats: {wins: 1486, losses: 1722},
+    universe: universes.earthbound,
+    past_smash_games: ['Smash Bros. Brawl'],
+    strongest_smash: {attack: 'PK Freeze (Down Special)', damage: 22},
+    jump_height: 29.41,
+    weight: {class: 'Middle Weight', weight_value: 94},
+    speeds: {
+      initial_dash: 1.3,
+      run_speed: 1.5,
+      air_speed: 1.1,
+      fall_speed: 1.37,
+      fast_fall_speed: 2.192,
+    },
+    pros: ['Fast attack speed', 'Good range', 'Good edge guarder', 'Stronest forward throw in game'],
+    cons: ['Low mobility', 'Very reliant on zoning tools', 'Difficult to use recovery'],
+    smash_wiki: 'https://ssbworld.com/characters/Lucas_(SSB4)',
+    images: {
+      large:'./images/characters/lucas.png',
+      icon: './images/character_icons/lucas_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/lucas_head.png'
+    }
+  },
+  {
+    name: 'Lucina',
+    counter: true,
+    tier: {tier: 'B', rank: 14},
+    world_stats: {wins: 1288, losses: 1502},
+    universe: universes.fire_emblem,
+    past_smash_games: [],
+    strongest_smash: {attack: 'Shield Breaker (Neutral Special fully charged)', damage: 23},
+    jump_height: 33.66,
+    weight: {class: 'Middle Weight', weight_value: 90},
+    speeds: {
+      initial_dash: 1.5,
+      run_speed: 1.79,
+      air_speed: 1.02,
+      fall_speed: 1.58,
+      fast_fall_speed: 2.53,
+    },
+    pros: ['Great air speed', 'Strong and quick shield breaker', 'Tied with marth for fastest walker in game'],
+    cons: ['Lacks range compared to Marth', 'Lighter than Marth', 'Vulnerable to edge gaurding'],
+    smash_wiki: 'https://ssbworld.com/characters/Lucina_(SSB4)',
+    images: {
+      large:'./images/characters/lucina.png',
+      icon: './images/character_icons/lucina_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/lucina_head.png'
+    }
+  },
+  {
+    name: 'Luigi',
+    counter: false,
+    tier: {tier: 'B', rank: 18},
+    world_stats: {wins: 2547, losses: 2493},
+    universe: universe.mario,
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee', 'Smash Bros. (64)'],
+    strongest_smash: {attack: 'Green Missle (Neutral Special - misfired)', damage: 25},
+    jump_height: 44,
+    weight: {class: 'Middle Weight', weight_value: 97},
+    speeds: {
+      initial_dash: 1.28,
+      run_speed: 1.5,
+      air_speed: .73,
+      fall_speed: 1.25,
+      fast_fall_speed: 2,
+    },
+    pros: ['Great combos', 'Very strong punishes', 'Powerful KO moves'],
+    cons: ['Lacks range', 'Second slowest aerial mobility', 'predictable recovery'],
+    smash_wiki: 'https://ssbworld.com/characters/Luigi_(SSB4)',
+    images: {
+      large:'./images/characters/luigi.png',
+      icon: './images/character_icons/luigi_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/luigi_head.png'
+    }
+  },
+  {
+    name: 'Mario',
+    counter: false,
+    tier: {tier: 'A', rank: 9},
+    world_stats: {wins: 6381, losses: 5976},
+    universe: universe.mario,
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee', 'Smash Bros. (64)'],
+    strongest_smash: {attack: 'Forward Smash', damage: 17},
+    jump_height: 36.33,
+    weight: {class: 'Middle Weight', weight_value: 98},
+    speeds: {
+      initial_dash: 1.6,
+      run_speed: 1.6,
+      air_speed: 1.15,
+      fall_speed: 1.5,
+      fast_fall_speed: 2.4,
+    },
+    pros: ['Very balanced', 'Great combo potential', 'Great punishes and quick speed'],
+    cons: ['Low damage output', 'Limited range', 'Limited recovery'],
+    smash_wiki: 'https://ssbworld.com/characters/Mario_(SSB4)',
+    images: {
+      large:'./images/characters/mario.png',
+      icon: './images/character_icons/mario_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/mario_head.png'
+    }
+  },
+  {
+    name: 'Marth',
+    counter: true,
+    tier: {tier: 'A', rank: 11},
+    world_stats: {wins: 6381, losses: 5976},
+    universe: universes.fire_emblem,
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee'],
+    strongest_smash: {attack: 'Shield Breaker (Neutral Special fully charged)', damage: 24},
+    jump_height: 36.66,
+    weight: {class: 'Middle Weight', weight_value: 90},
+    speeds: {
+      initial_dash: 1.5,
+      run_speed: 1.79,
+      air_speed: 1.02,
+      fall_speed: 1.58,
+      fast_fall_speed: 2.53,
+    },
+    pros: ['Strong aerial game', 'Fast moves', 'Hitting with tip of sword provides damage boost', 'Has kill throw'],
+    cons: ['Throws only do 3/4%', 'Poor horizontal recovery', 'Predictable recovery'],
+    smash_wiki: 'https://ssbworld.com/characters/Marth_(SSB4)',
+    images: {
+      large:'./images/characters/marth.png',
+      icon: './images/character_icons/marth_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/marth_head.png'
+    }
+  },
+  {
+    name: 'Mega Man',
+    counter: false,
+    tier: {tier: 'C', rank: 27},
+    world_stats: {wins: 1441, losses: 1467},
+    universe: universes.mega_man,
+    past_smash_games: [],
+    strongest_smash: {attack: 'Forward Smash', damage: 19},
+    jump_height: 32.8,
+    weight: {class: 'Heavy Weight', weight_value: 102},
+    speeds: {
+      initial_dash: 1.5,
+      run_speed: 1.46,
+      air_speed: 1.1,
+      fall_speed: 1.8,
+      fast_fall_speed: 2.88,
+    },
+    pros: ['Heavier than average', 'Great recovery options', 'Very good at edge guarding', 'Excels at mid-range spacing'],
+    cons: ['Nearly all kill moves are easily punished', 'Almost no combo ability', 'Very reliant on projectiles'],
+    smash_wiki: 'https://ssbworld.com/characters/Mega_Man_(SSB4)',
+    images: {
+      large:'./images/characters/mega_man.png',
+      icon: './images/character_icons/mega_man_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/mega_man_head.png'
+    }
+  },
+  {
+    name: 'Meta Knight',
+    counter: false,
+    tier: {tier: 'B', rank: 16},
+    world_stats: {wins: 2077, losses: 2144},
+    universe: universes.kirby,
+    past_smash_games: ['Smash Bros. Brawl'],
+    strongest_smash: {attack: 'Forward Smash', damage: 16},
+    jump_height: 32,
+    weight: {class: 'Feather Weight', weight_value: 80},
+    speeds: {
+      initial_dash: 1.7,
+      run_speed: 1.9,
+      air_speed: .99,
+      fall_speed: 1.66,
+      fast_fall_speed: 2.66,
+    },
+    pros: ['Good matchups across the board', 'Reliable kill setups', 'Small hurtbox', 'Disjointed hitboxes'],
+    cons: ['Very low damage per hit', 'Lightweight', 'Poor range'],
+    smash_wiki: 'https://ssbworld.com/characters/Meta_Knight_(SSB4)',
+    images: {
+      large:'./images/characters/meta_knight.png',
+      icon: './images/character_icons/meta_knight_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/meta_knight_head.png'
+    }
+  },
+  {
+    name: 'Mewtwo',
+    counter: false,
+    tier: {tier: 'A', rank: 10},
+    world_stats: {wins: 2994, losses: 2912},
+    universe: universes.pokemon,
+    past_smash_games: ['Smash Bros. Melee'],
+    strongest_smash: {attack: 'Shadow Ball (Neutral Special fully charged)', damage: 25},
+    jump_height: 31.11,
+    weight: {class: 'Balloon Weight', weight_value: 74},
+    speeds: {
+      initial_dash: 1.4,
+      run_speed: 2.05,
+      air_speed: 1.25,
+      fall_speed: 1.5,
+      fast_fall_speed: 2.4,
+    },
+    pros: ['Great combo ability', '2 very powerful kill throws', 'Good range', 'Air dodge makes him invisible and hard to read'],
+    cons: ['Lightweight', 'Big Target', 'Floaty in the air'],
+    smash_wiki: 'https://ssbworld.com/characters/Mewtwo_(SSB4)',
+    images: {
+      large:'./images/characters/mewtwo.png',
+      icon: './images/character_icons/mewtwo_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/mewtwo_head.png'
+    }
+  },
+  {
+    name: 'Mii Brawler',
+    counter: false,
+    tier: {tier: 'N/A', rank: 'N/A'},
+    world_stats: {wins: 290, losses: 303},
+    universe: universes.smash_bros,
+    past_smash_games: [],
+    strongest_smash: {attack: 'Forward Smash', damage: 18},
+    jump_height: 35,
+    weight: {class: 'Heavy Weight', weight_value: 100},
+    speeds: {
+      initial_dash: 1.6,
+      run_speed: 1.72,
+      air_speed: 1.2,
+      fall_speed: 1.7,
+      fast_fall_speed: 2.72,
+    },
+    pros: ['Fast air and running speed', 'Fast attacks', 'High jump', 'Strong aerial game'],
+    cons: ['Worst vertical recovery in game', 'Has almost no range', 'Lacks strong kill moves'],
+    smash_wiki: 'https://ssbworld.com/characters/Mii_Brawler_(SSB4)',
+    images: {
+      large:'./images/characters/mii_brawler.png',
+      icon: './images/character_icons/smash_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/mii_brawler_head.png'
+    }
+  },
+  {
+    name: 'Mii Gunner',
+    counter: false,
+    tier: {tier: 'N/A', rank: 'N/A'},
+    world_stats: {wins: 141, losses: 175},
+    universe: universes.smash_bros,
+    past_smash_games: [],
+    strongest_smash: {attack: 'Charge Blast (Neutral Special fully charged)', damage: 22},
+    jump_height: 32,
+    weight: {class: 'Heavy Weight', weight_value: 100},
+    speeds: {
+      initial_dash: 1.6,
+      run_speed: 1.3,
+      air_speed: 1.05,
+      fall_speed: 1.45,
+      fast_fall_speed: 2.32,
+    },
+    pros: ['Wide range of projectiles', 'Strong range', 'Quick close range attacks'],
+    cons: ['Low Damage Output', 'No reliable kill confirms', 'Punishable recovery', 'Lacks a reliable combo breaker'],
+    smash_wiki: 'https://ssbworld.com/characters/Mii_Gunner_(SSB4)',
+    images: {
+      large:'./images/characters/mii_gunner.png',
+      icon: './images/character_icons/smash_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/mii_gunner_head.png'
+    }
+  },
+  {
+    name: 'Mii Swordfighter',
+    counter: false,
+    tier: {tier: 'N/A', rank: 'N/A'},
+    world_stats: {wins: 31, losses: 48},
+    universe: universes.smash_bros,
+    past_smash_games: [],
+    strongest_smash: {attack: 'Forward Smash (tip)', damage: 16},
+    jump_height: 28.3,
+    weight: {class: 'Heavy Weight', weight_value: 100},
+    speeds: {
+      initial_dash: 1.3,
+      run_speed: 1.5,
+      air_speed: .96,
+      fall_speed: 1.6,
+      fast_fall_speed: 2.56,
+    },
+    pros: ['Good overall mobility', 'Strong projectile game', 'Versatile air game', 'Good low % combo game'],
+    cons: ['Below average kill power', 'Low range for a sword weilder', 'Lack of kill throws'],
+    smash_wiki: 'https://ssbworld.com/characters/Mii_Fighter_(SSB4)',
+    images: {
+      large:'./images/characters/mii_sword_fighter.png',
+      icon: './images/character_icons/smash_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/mii_sword_fighter_head.png'
+    }
+  },
+  {
+    name: 'Mr. Game & Watch',
+    counter: false,
+    tier: {tier: 'E', rank: 39},
+    world_stats: {wins: 964, losses: 1120},
+    universe: universes.game_and_watch,
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee'],
+    strongest_smash: {attack: 'Judge (Side Special - 1/9 chance of landing)', damage: 32},
+    jump_height: 27.51,
+    weight: {class: 'Feather Weight', weight_value: 75},
+    speeds: {
+      initial_dash: 1.5,
+      run_speed: 1.53,
+      air_speed: 1.12,
+      fall_speed: 1.24,
+      fast_fall_speed: 1.98,
+    },
+    pros: ['Great Air Game', 'Excellent smashes', 'Lucky side special or full bucket can kill early', 'Good edge gaurding'],
+    cons: ['Light weight', 'Unreliable projectile', 'Somewhat poor ground game'],
+    smash_wiki: 'https://ssbworld.com/characters/Mr._Game_%26_Watch_(SSB4)',
+    images: {
+      large:'./images/characters/mr_game_and_watch.png',
+      icon: './images/character_icons/mr_game_and_watch_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/mr_game_and_watch_head.png'
+    }
+  },
+  {
+    name: 'Ness',
+    counter: false,
+    tier: {tier: 'C', rank: 28},
+    world_stats: {wins: 2994, losses: 2730},
+    universe: universes.earthbound,
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee', 'Smash Bros. (64)'],
+    strongest_smash: {attack: 'PK Flash (Neutral Special fully charged)', damage: 37},
+    jump_height: 34.48,
+    weight: {class: 'Middle Weight', weight_value: 94},
+    speeds: {
+      initial_dash: 1.3,
+      run_speed: 1.46,
+      air_speed: .96,
+      fall_speed: 1.31,
+      fast_fall_speed: 2.1,
+    },
+    pros: ['Great combos', 'Racks up damage quickly', 'Good range options, Great close options', 'Many reliable kill moves'],
+    cons: ['Slow dodging', 'Average mobility', 'Fairly slow and easiliy overwhelmed by fast characters'],
+    smash_wiki: 'https://ssbworld.com/characters/Ness_(SSB4)',
+    images: {
+      large:'./images/characters/ness.png',
+      icon: './images/character_icons/ness_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/ness_head.png'
+    }
+  },
+  {
+    name: 'Olimar',
+    counter: false,
+    tier: {tier: 'C', rank: 21},
+    world_stats: {wins: 1100, losses: 1124},
+    universe: universes.pikmin,
+    past_smash_games: ['Smash Bros. Brawl'],
+    strongest_smash: {attack: 'Forward Smash (Purple Pikmin)', damage: 20},
+    jump_height: 33.5,
+    weight: {class: 'Feather Weight', weight_value: 79},
+    speeds: {
+      initial_dash: 1.6,
+      run_speed: 1.47,
+      air_speed: .82,
+      fall_speed: 1.35,
+      fast_fall_speed: 2.16,
+    },
+    pros: ['Small size makes doding easier', 'Racks up damage fast without having to approach', 'Strong Recovery', 'Has reliable kill options'],
+    cons: ['Light and easier to kill', 'Fast character give him trouble', 'Pikmin can desync from the line'],
+    smash_wiki: 'https://ssbworld.com/characters/Olimar_(SSB4)',
+    images: {
+      large:'./images/characters/olimar.png',
+      icon: './images/character_icons/olimar_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/olimar_head.png'
+    }
+  },
+  {
+    name: 'Pac-Man',
+    counter: false,
+    tier: {tier: 'F', rank: 46},
+    world_stats: {wins: 1300, losses: 1222},
+    universe: universes.pac_man,
+    past_smash_games: [],
+    strongest_smash: {attack: 'Forward Smash', damage: 16},
+    jump_height: 34.1,
+    weight: {class: 'Middle Weight', weight_value: 95},
+    speeds: {
+      initial_dash: 1.6,
+      run_speed: 1.52,
+      air_speed: 1.04,
+      fall_speed: 1.35,
+      fast_fall_speed: 2.16,
+    },
+    pros: ['Not many bad matchups', 'Neutral B is very versatile', 'Good at damage racking'],
+    cons: ['Poor throw', 'Mediocre mobility', 'Average range'],
+    smash_wiki: 'https://ssbworld.com/characters/Pac-Man_(SSB4)',
+    images: {
+      large:'./images/characters/pac_man.png',
+      icon: './images/character_icons/pac_man_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/pac_man_head.png'
+    }
+  },
+  {
+    name: 'Palutena',
+    counter: true,
+    tier: {tier: 'E', rank: 45},
+    world_stats: {wins: 442, losses: 509},
+    universe: universes.kid_icarus,
+    past_smash_games: [],
+    strongest_smash: {attack: 'Forward Smash', damage: 16},
+    jump_height: 35.9,
+    weight: {class: 'Middle Weight', weight_value: 91},
+    speeds: {
+      initial_dash: 1.5,
+      run_speed: 1.88,
+      air_speed: .91,
+      fall_speed: 1.4,
+      fast_fall_speed: 2.24,
+    },
+    pros: ['Great Aerial moves', 'Fast ground movement', 'Good spacing tools'],
+    cons: ['Light and easy to launch', 'Tall and easier to hit than most characters', 'Slow kill moves'],
+    smash_wiki: 'https://ssbworld.com/characters/Palutena_(SSB4)',
+    images: {
+      large:'./images/characters/palutena.png',
+      icon: './images/character_icons/palutena_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/palutena_head.png'
+    }
+  },
+  {
+    name: 'Peach',
+    counter: true,
+    tier: {tier: 'B', rank: 20},
+    world_stats: {wins: 1433, losses: 1615},
+    universe: universe.mario,
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee'],
+    strongest_smash: {attack: 'Up Smash', damage: 17},
+    jump_height: 30.03,
+    weight: {class: 'Middle Weight', weight_value: 89},
+    speeds: {
+      initial_dash: 1.5,
+      run_speed: 1.42,
+      air_speed: .95,
+      fall_speed: 1.15,
+      fast_fall_speed: 1.84,
+    },
+    pros: ['Good at keep away game', 'Floating can help her control space', 'Decent combo game'],
+    cons: ['Slow in General', 'Hard to kill with', 'Very floaty', 'Counter is slow'],
+    smash_wiki: 'https://ssbworld.com/characters/Peach_(SSB4)',
+    images: {
+      large:'./images/characters/peach.png',
+      icon: './images/character_icons/peach_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/peach_head.png'
+    }
+  },
+  {
+    name: 'Pikachu',
+    counter: false,
+    tier: {tier: 'B', rank: 15},
+    world_stats: {wins: 1917, losses: 2113},
+    universe: universes.pokemon,
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee', 'Smash Bros. (64)'],
+    strongest_smash: {attack: 'Skull Bash (Side Special fully charged)', damage: 21},
+    jump_height: 35.5,
+    weight: {class: 'Feather Weight', weight_value:79},
+    speeds: {
+      initial_dash: 1.8,
+      run_speed: 1.85,
+      air_speed: .91,
+      fall_speed: 1.55,
+      fast_fall_speed: 2.48,
+    },
+    pros: ['Many powerful smashes', 'Very fast and small', 'Grabs good and easy to combo with', 'Great aerial combos'],
+    cons: ['Light weight', 'Skull bash can be predictable', 'short reach on most attacks'],
+    smash_wiki: 'https://www.ssbwiki.com/Pikachu_(SSB4)',
+    images: {
+      large:'./images/characters/pikachu.png',
+      icon: './images/character_icons/pikachu_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/pikachu_head.png'
+    }
+  },
+  {
+    name: 'Pit',
+    counter: false,
+    tier: {tier: 'D', rank: 32},
+    world_stats: {wins: 576, losses: 607},
+    universe: universes.kid_icarus,
+    past_smash_games: ['Smash Bros. Brawl'],
+    strongest_smash: {attack: 'Forward Smash (2-hit combo)', damage: 15},
+    jump_height: 31,
+    weight: 96,
+    speeds: {
+      initial_dash: 1.5,
+      run_speed: 1.66,
+      air_speed: .89,
+      fall_speed: 1.48,
+      fast_fall_speed: 2.37,
+    },
+    pros: ['Fantastic Recovery', 'Good spacing options', 'No bad matchups', 'Arrows have greater range than dark Pit and can be curved'],
+    cons: ['Low KO potential', 'Does not have great edge guarding options'],
+    smash_wiki: 'https://www.ssbwiki.com/Pit_(SSB4)',
+    images: {
+      large:'./images/characters/pit.png',
+      icon: './images/character_icons/pit_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/pit_head.png'
+    }
+  },
+  {
+    name: 'R.O.B.',
+    counter: false,
+    tier: {tier: 'D', rank: 36},
+    world_stats: {wins: 1861, losses: 1935},
+    universe: universes.rob,
+    past_smash_games: ['Smash Bros. Brawl'],
+    strongest_smash: {attack: 'Robo Beam (Neutral Special fully charged point blank)',damage: 17},
+    jump_height: 38,
+    weight: {class: 'Heavy Weight', weight_value: 106},
+    speeds: {
+      initial_dash: 1.3,
+      run_speed: 1.57,
+      air_speed: 1.08,
+      fall_speed: 1.6,
+      fast_fall_speed: 2.56,
+    },
+    pros: ['Up and Side smashes KO early', 'Very relaible recovery', 'Fantastic zoning game', 'Can be played defensive or offensively'],
+    cons: ['Prone to combos', 'Predictable recovery', 'Weak against faster players who can rush down'],
+    smash_wiki: 'https://www.ssbwiki.com/R.O.B._(SSB4)',
+    images: {
+      large:'./images/characters/rob.png',
+      icon: './images/character_icons/rob_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/rob_head.png'
+    }
+  },
+  {
+    name: 'Robin',
+    counter: false,
+    tier: {tier: 'D', rank: 37},
+    world_stats: {wins: 1178, losses: 1244},
+    universe: universes.fire_emblem,
+    past_smash_games: [],
+    strongest_smash: {attack: 'Forward Smash', damage: 16},
+    jump_height: 33.21,
+    weight: {class: 'Middle Weight', weight_value: 95},
+    speeds: {
+      initial_dash: 1.5,
+      run_speed: 1.15,
+      air_speed: 1,
+      fall_speed: 1.5,
+      fast_fall_speed: 2.4,
+    },
+    pros: ['Very strong zoning game', 'Sword has great range, priority, and disjointed hitbox', 'Most significant health restoration in game'],
+    cons: ['Slowest run speed', 'Slow in general', 'Low grab range', 'Limited uses for specials, smashes, and aerials'],
+    smash_wiki: 'https://www.ssbwiki.com/Robin_(SSB4)',
+    images: {
+      large:'./images/characters/robin.png',
+      icon: './images/character_icons/robin_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/robin_head.png'
+    }
+  },
+  {
+    name: 'Rosalina & Luma',
+    counter: false,
+    tier: {tier: 'A', rank: 5},
+    world_stats: {wins: 3438, losses: 3438},
+    universe: universe.mario,
+    past_smash_games: [],
+    strongest_smash: {attack: 'Luma Shot (Neutral Special stage 5)', damage: 16},
+    jump_height: 40,
+    weight: {class: 'Feather Weight', weight_value: 77},
+    speeds: {
+      initial_dash: 1.5,
+      run_speed: 1.63,
+      air_speed: 1,
+      fall_speed: 1.2,
+      fast_fall_speed: 1.92,
+    },
+    pros: ['Great zoning game', 'Great range and disjointed hitboxes', 'Quick and powerful smashes with little ending lag', 'Long range recovery'],
+    cons: ['Large light weight target', 'Her options become limited without Luma', 'Floaty in general'],
+    smash_wiki: 'https://www.ssbwiki.com/Rosalina_%26_Luma_(SSB4)',
+    images: {
+      large:'./images/characters/rosalina.png',
+      icon: './images/character_icons/rosalina_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/rosalina_head.png'
+    }
+  },
+  {
+    name: 'Roy',
+    counter: true,
+    tier: {tier: 'E', rank: 42},
+    world_stats: {wins: 1352, losses: 1372},
+    universe: universes.fire_emblem,
+    past_smash_games: ['Smash Bros. Melee'],
+    strongest_smash: {attack: 'Fire Blade (Neutral Special fully charged)', damage: 50},
+    jump_height: 30.97,
+    weight: {class: 'Middle Weight', weight_value: 95},
+    speeds: {
+      initial_dash: 1.4,
+      run_speed: 1.95,
+      air_speed: 1.24,
+      fall_speed: 1.8,
+      fast_fall_speed: 2.9,
+    },
+    pros: ['Good ground and air speed', 'Excellent kill power', 'Excellent combo game', 'Good grab game'],
+    cons: ['Aerials are punishable', 'Fast faller giving him good combo game but also susceptible to combos', 'Recovery susceptible to edge gaurding'],
+    smash_wiki: 'https://www.ssbwiki.com/Roy_(SSB4)',
+    images: {
+      large:'./images/characters/roy.png',
+      icon: './images/character_icons/roy_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/roy_head.png'
+    }
+  },
+  {
+    name: 'Ryu',
+    counter: false,
+    tier: {tier: 'A', rank: 12},
+    world_stats: {wins: 2562, losses: 2734},
+    universe: universes.street_fighter,
+    past_smash_games: [],
+    strongest_smash: {attack: 'Up Smash', damage: 17},
+    jump_height: 26,
+    weight: {class: 'Heavy Weight', weight_value: 103},
+    speeds: {
+      initial_dash: 1.6,
+      run_speed: 1.6,
+      air_speed: 1.12,
+      fall_speed: 1.6,
+      fast_fall_speed: 2.24,
+    },
+    pros: ['Combo oriented fighter', 'Effective and unpredictable recovery', 'Has good combo breaking options', 'Moveset does solid damage with good speed'],
+    cons: ['Overall mobility below average', 'Difficulty appraoching', 'Ground attacks have short ranges', 'Lacks reliable finishing moves'],
+    smash_wiki: 'https://www.ssbwiki.com/Ryu_(SSB4)',
+    images: {
+      large:'./images/characters/ryu.png',
+      icon: './images/character_icons/ryu_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/ryu_head.png'
+    }
+  },
+  {
+    name: 'Samus',
+    counter: false,
+    tier: {tier: 'D', rank: 38},
+    world_stats: {wins: 1265, losses: 1351},
+    universe: universes.metroid,
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee', 'Smash Bros. (64)'],
+    strongest_smash: {attack: 'Charge Shot (Neutral Special fully charged)', damage: 25},
+    jump_height: 37,
+    weight: {class: 'Heavy Weight', weight_value: 108},
+    speeds: {
+      initial_dash: 1.86,
+      run_speed: 1.5,
+      air_speed: 1.03,
+      fall_speed: 1.3,
+      fast_fall_speed: 2.08,
+    },
+    pros: ['Heavier and harder to kill', 'Very strong smashes', 'Slows down rushing character with her approach countering tools'],
+    cons: ['Deals poorly with pressure', 'Heavy and floaty allowing her to be juggled', 'Drastically different play style from rest of cast - tedious to learn'],
+    smash_wiki: 'https://www.ssbwiki.com/Samus_(SSB4)',
+    images: {
+      large:'./images/characters/samus.png',
+      icon: './images/character_icons/samus_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/samus_head.png'
+    }
+  },
+  {
+    name: 'Sheik',
+    counter: false,
+    tier: {tier: 'A', rank: 4},
+    world_stats: {wins: 5590, losses: 4946},
+    universe: universes.legend_of_zelda,
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee'],
+    strongest_smash: {attack: 'Up Smash', damage: 15},
+    jump_height: 39,
+    weight: {class: 'Feather Weight', weight_value: 81},
+    speeds: {
+      initial_dash: 1.7,
+      run_speed: 2.02,
+      air_speed: 1.1,
+      fall_speed: 1.75,
+      fast_fall_speed: 2.8,
+    },
+    pros: ['One of the best recoveries in the game', 'Great air and ground mobility', 'Great roll dodging', 'Great combo game', 'Great edge gaurding'],
+    cons: ['Does\'t have great KO options', 'Lightweight and easier to kill', 'Most moves to very little damage', 'Average reach'],
+    smash_wiki: 'https://www.ssbwiki.com/Sheik_(SSB4)',
+    images: {
+      large:'./images/characters/sheik.png',
+      icon: './images/character_icons/sheik_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/sheik_head.png'
+    }
+  },
+  {
+    name: 'Shulk',
+    counter: true,
+    tier: {tier: 'D', rank: 35},
+    world_stats: {wins: 1020, losses: 1160},
+    universe: universes.xenoblade,
+    past_smash_games: [],
+    strongest_smash: {attack: 'Forward Smash (2-hit combo)', damage: 18},
+    jump_height: 34.8,
+    weight: {class: 'Heavy Weight', weight_value: 102},
+    speeds: {
+      initial_dash: 1.5,
+      run_speed: 1.52,
+      air_speed: 1.06,
+      fall_speed: 1.5,
+      fast_fall_speed: 2.4,
+    },
+    pros: ['Good mobility for a heavyweight', 'Very disjointed hixbox', 'Powerful aerial moveset', 'Smash attacks very powerful'],
+    cons: ['Very slow moveset', 'Most powerful attacks are very short range and slow', 'Lacks combo breakers'],
+    smash_wiki: 'https://www.ssbwiki.com/Shulk_(SSB4)',
+    images: {
+      large:'./images/characters/shulk.png',
+      icon: './images/character_icons/shulk_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/shulk_head.png'
+    }
+  },
+  {
+    name: 'Sonic',
+    counter: false,
+    tier: {tier: 'A', rank: 8},
+    world_stats: {wins: 4111, losses: 3925},
+    universe: universes.sonic,
+    past_smash_games: ['Smash Bros. Brawl'],
+    strongest_smash: {attack: 'Back Aerial', damage: 14},
+    jump_height: 35,
+    weight: {class: 'Middle Weight', weight_value: 94},
+    speeds: {
+      initial_dash: 1.5,
+      run_speed: 3.5,
+      air_speed: 1.15,
+      fall_speed: 1.45,
+      fast_fall_speed: 2.32,
+    },
+    pros: ['Fastest character in the game', 'Great combos', 'Good at racking up damage quickly while staying safe'],
+    cons: ['Struggles against zoners', 'Not many strong approach options', 'Stuggles against very defensive play styles'],
+    smash_wiki: 'https://www.ssbwiki.com/Sonic_(SSB4)',
+    images: {
+      large:'./images/characters/sonic.png',
+      icon: './images/character_icons/sonic_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/sonic_head.png'
+    }
+  },
+  {
+    name: 'Toon Link',
+    counter: false,
+    tier: {tier: 'C', rank: 23},
+    world_stats: {wins: 2190, losses: 2311},
+    universe: universes.legend_of_zelda,
+    past_smash_games: ['Smash Bros. Brawl'],
+    strongest_smash: {attack: 'Down Aerial', damage: 16},
+    jump_height: 33.8,
+    weight: {class: 'Middle Weight', weight_value: 93},
+    speeds: {
+      initial_dash: 1.5,
+      run_speed: 1.73,
+      air_speed: .94,
+      fall_speed: 1.28,
+      fast_fall_speed: 2.05,
+    },
+    pros: ['Very good projectiles', 'Can easily rack up damage', 'Good speed and tools to slow down faster characters', 'Difficult to combo against'],
+    cons: ['Light and easy to KO', 'Slow and laggy grab', 'Has trouble landing the kill'],
+    smash_wiki: 'https://www.ssbwiki.com/Toon_Link_(SSB4)',
+    images: {
+      large:'./images/characters/toon_link.png',
+      icon: './images/character_icons/toon_link_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/toon_link_head.png'
+    }
+  },
+  {
+    name: 'Villager',
+    counter: false,
+    tier: {tier: 'C', rank: 25},
+    world_stats: {wins: 1426, losses: 1547},
+    universe: universes.animal_crossing,
+    past_smash_games: [],
+    strongest_smash: {attack: 'Timber (Down Special - Stage 3 tree)', damage: 25},
+    jump_height: 32.5,
+    weight: {class: 'Middle Weight', weight_value: 97},
+    speeds: {
+      initial_dash: 1.5,
+      run_speed: 1.27,
+      air_speed: .94,
+      fall_speed: 1.32,
+      fast_fall_speed: 2.11,
+    },
+    pros: ['Potent edge gaurder', 'Strong camping game', 'Good projectiles', 'Amazing recovery'],
+    cons: ['Slow grab', 'Can be difficult to lan KO moves', 'Slow dash speed'],
+    smash_wiki: 'https://www.ssbwiki.com/Villager_(SSB4)',
+    images: {
+      large:'./images/characters/villager.png',
+      icon: './images/character_icons/villager_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/villager_head.png'
+    }
+  },
+  {
+    name: 'Wario',
+    counter: false,
+    tier: {tier: 'E', rank: 41},
+    world_stats: {wins: 1244, losses: 1139},
+    universe: universes.wario,
+    past_smash_games: ['Smash Bros. Brawl'],
+    strongest_smash: {attack: 'Wario Waft (Down Special fully charged)', damage: 27},
+    jump_height: 30.5,
+    weight: {class: 'Heavy Weight', weight_value: 107},
+    speeds: {
+      initial_dash: 1.3,
+      run_speed: 1.5,
+      air_speed: 1.21,
+      fall_speed: 1.61,
+      fast_fall_speed: 2.58,
+    },
+    pros: ['Unorthodox and unpredictable special moves', 'Great air speed', 'Excellent amount of recovery options'],
+    cons: ['Poor reach and lacks true projectile', 'Susceptible to camping', 'Lacks reliable KO moves'],
+    smash_wiki: 'https://www.ssbwiki.com/Wario_(SSB4)',
+    images: {
+      large:'./images/characters/wario.png',
+      icon: './images/character_icons/wario_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/wario_head.png'
+    }
+  },
+  {
+    name: 'Wii Fit Trainer',
+    counter: false,
+    tier: {tier: 'F', rank: 51},
+    world_stats: {wins: 1032, losses: 838},
+    universe: universes.wii_fit,
+    past_smash_games: [],
+    strongest_smash: {attack: 'Up Smash', damage: 18},
+    jump_height: 35.6,
+    weight: {class: 'Middle Weight', weight_value: 96},
+    speeds: {
+      initial_dash: 1.3,
+      run_speed: 1.5,
+      air_speed: 1.21,
+      fall_speed: 1.61,
+      fast_fall_speed: 2.58,
+    },
+    pros: ['Unusal hiboxes', 'Good overall mobility', 'Good evasive moves', 'Versatile special moves'],
+    cons: ['Difficult to land powerful attacks on short characters', 'Poor grab game', 'Moves have long ending lag'],
+    smash_wiki: 'https://www.ssbwiki.com/Wii_Fit_Trainer_(SSB4)',
+    images: {
+      large:'./images/characters/wii_fit_trainer.png',
+      icon: './images/character_icons/wii_fit_trainer_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/wii_fit_trainer_head.png'
+    }
+  },
+  {
+    name: 'Yoshi',
+    counter: false,
+    tier: {tier: 'D', rank: 34},
+    world_stats: {wins: 2092, losses: 2294},
+    universe: universes.yoshi,
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee', 'Smash Bros. (64)'],
+    strongest_smash: {attack: 'Forward Smash', damage: 15},
+    jump_height: 36.1,
+    weight: {class: 'Heavy Weight', weight_value: 104},
+    speeds: {
+      initial_dash: 1.33,
+      run_speed: 1.86,
+      air_speed: 1.28,
+      fall_speed: 1.29,
+      fast_fall_speed: 2.06,
+    },
+    pros: ['Excellent air mobility', 'Fastest air speed and 2nd highest jump', 'Good combos', 'Good approach and edge gaurding options'],
+    cons: ['Very poor grab game', 'Poor ground defensive options', 'Lacks strong KO moves'],
+    smash_wiki: 'https://www.ssbwiki.com/Yoshi_(SSB4)',
+    images: {
+      large:'./images/characters/yoshi.png',
+      icon: './images/character_icons/yoshi_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/yoshi_head.png'
+    }
+  },
+  {
+    name: 'Zelda',
+    counter: false,
+    tier: {tier: 'G', rank: 54},
+    world_stats: {wins: 317, losses: 409},
+    universe: universes.legend_of_zelda,
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee'],
+    strongest_smash: {attack: 'Forward Smash', damage: 16},
+    jump_height: 35.9,
+    weight: {class: 'Middle Weight', weight_value: 91},
+    speeds: {
+      initial_dash: 1.5,
+      run_speed: 1.88,
+      air_speed: .91,
+      fall_speed: 1.15,
+      fast_fall_speed: 1.84,
+    },
+    pros: ['Has many KO options', 'Good zoning', 'Down special is good for edge guarding'],
+    cons: ['Slow mobility', 'Light weight', 'Tall hurtbox', 'Laggy moves'],
+    smash_wiki: 'https://ssbworld.com/characters/Zelda_(SSB4)',
+    images: {
+      large:'./images/characters/zelda.png',
+      icon: './images/character_icons/zelda_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/zelda_head.png'
+    }
+  },
+  {
+    name: 'Zero Suit Samus',
+    counter: false,
+    tier: {tier: 'A', rank: 6},
+    world_stats: {wins: 4437, losses: 3942},
+    universe: 'Metriod',
+    past_smash_games: ['Smash Bros. Brawl'],
+    strongest_smash: { attack: 'Forward Smash (2-hit combo)', damage: 16},
+    jump_height: 44.5,
+    weight: {class: 'Feather Weight', weight_value: 80},
+    speeds: {
+      initial_dash: 1.7,
+      run_speed: 2.1,
+      air_speed: 1.2,
+      fall_speed: 1.7,
+      fast_fall_speed: 1.72,
+    },
+    pros: ['Great recovery, difficult to edge guard against', 'Amazing mobility', 'Has many KO moves', 'Great reach'],
+    cons: ['Relies a lot on reads', 'Light weight and bigger target', 'Some character can crouch under her moves', 'Slow grab'],
+    smash_wiki: 'https://ssbworld.com/characters/Zero_Suit_Samus_(SSB4)',
+    images: {
+      large:'./images/characters/zero_suit_samus.png',
+      icon: './images/character_icons/zero_suit_samus_icon.png',
+      small_icon: './images/charcter_icons/small_character_icons/zero_suit_samus_head.png'
+    }
+  }
+];
+
+const stages = [
+  {
+    name: '3D Land', 
+    dlc: false,
+    universe: universes.mario,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/3D_Land',
+    stage_image: './images/stages/3d_land.png',
+    past_smash_games: []
+  },
+  {
+    name: '75m', 
+    dlc: false,
+    universe: universes.donkey_kong,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/75m',
+    stage_image: './images/stages/75m.png',
+    past_smash_games: ['Smash Bros. Brawl']
+  },
+  {
+    name: 'Arena Ferox',
+    dlc: false,
+    universe: universes.fire_emblem,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Arena_Ferox',
+    stage_image: './images/stages/arena_ferox.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Balloon Fight', 
+    dlc: false,
+    universe: universes.balloon_fight,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Balloon_Fight',
+    stage_image: './images/stages/balloon_fight.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Battlefield', 
+    dlc: false,
+    universe: universes.smash_bros,
+    wii_u: true,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Battlefield_(SSB4)',
+    stage_image: './images/stages/battlefield.jpg',
+    past_smash_games: []
+  },
+  {
+    name: 'Big Battlefield',
+    dlc: false,
+    universe: universes.smash_bros,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Big_Battlefield_(SSB4)',
+    stage_image: './images/stages/big_battlefield.jpg',
+    past_smash_games: []
+  },
+  {
+    name: 'Boxing Ring',
+    dlc: false,
+    universe: universes.punch_out,
+    wii_u: true,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Boxing_Ring',
+    stage_image: './images/stages/boxing_ring.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Bridge of Eldin', 
+    dlc: false,
+    universe: universes.legend_of_zelda,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Bridge_of_Eldin',
+    stage_image: './images/stages/bridge_of_eldin.png',
+    past_smash_games: ['Smash Bros. Brawl']
+  },
+  {
+    name: 'Brinstar', 
+    dlc: false,
+    universe: universes.metroid,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Brinstar',
+    stage_image: './images/stages/brinstar.png',
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee']
+  },
+  {
+    name: 'Castle Siege',
+    dlc: false,
+    universe: universes.fire_emblem,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki: 'https://www.ssbwiki.com/Castle_Siege',
+    stage_image: './images/stages/castle_seige.png',
+    past_smash_games: ['Smash Bros. Brawl']
+  },
+  {
+    name: 'Coliseum', 
+    dlc: false,
+    universe: universes.fire_emblem,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Coliseum',
+    stage_image: './images/stages/coliseum.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Corneria',
+    dlc: false,
+    universe: universes.star_fox,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki: 'https://www.ssbwiki.com/Corneria',
+    stage_image: './images/stages/corneria.png',
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee']
+  },
+  {
+    name: 'Delfino Plaza', 
+    dlc: false,
+    universe: universes.mario,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Delfino_Plaza',
+    stage_image: './images/stages/delfino_plaza.jpg',
+    past_smash_games: ['Smash Bros. Brawl']
+  },
+  {
+    name: 'Distant Planet',
+    dlc: false,
+    universe: universes.pikmin,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Distant_Planet',
+    stage_image: './images/stages/distant_planet.png',
+    past_smash_games: ['Smash Bros. Brawl']
+  },
+  {
+    name: 'Dreamland GB',
+    dlc: false,
+    universe: universes.kirby,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Dream_Land_(SSB4)',
+    stage_image: './images/stages/dream_land_64.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Deamland', 
+    dlc: true,
+    universe: universes.kirby,
+    wii_u: true,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Dream_Land_(SSB)',
+    stage_image: './images/stages/dream_land_GB.png',
+    past_smash_games: ['Smash Bros. Melee', 'Smash Bros. (64)']
+  },
+  {
+    name: 'Duck Hunt',
+    dlc: true,
+    universe: universes.duck_hunt,
+    wii_u: true,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Duck_Hunt_(stage)',
+    stage_image: './images/stages/duck_hunt.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Final Destination',
+    dlc: false,
+    universe: universes.smash_bros,
+    wii_u: true,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Final_Destination_(SSB4)',
+    stage_image: './images/stages/final_destination.jpg',
+    past_smash_games: []
+  },
+  {
+    name: 'Find Mii',
+    dlc: false,
+    universe: universes.find_mii,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Find_Mii',
+    stage_image: './images/stages/find_mii.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Flat Zone 2',
+    dlc: false,
+    universe: universes.game_and_watch,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Flat_Zone_2',
+    stage_image: './images/stages/flat_zone_2.png',
+    past_smash_games: ['Smash Bros. Brawl']
+  },
+  {
+    name: 'Flat Zone X',
+    dlc: false,
+    universe: universes.game_and_watch,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Flat_Zone_X',
+    stage_image: './images/stages/flat_zone_x.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Gamer',
+    dlc: false,
+    universe: universes.wario,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Gamer',
+    stage_image: './images/stages/gamer.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Garden of Hope',
+    dlc: false,
+    universe: universes.pikmin,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Garden_of_Hope',
+    stage_image: './images/stages/garden_of_hope.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Gaur Plain',
+    dlc: false,
+    universe: universes.xenoblade,
+    wii_u: true,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Gaur_Plain',
+    stage_image: './images/stages/gaur_plain.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Gerudo Valley',
+    dlc: false,
+    universe: universes.legend_of_zelda,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Gerudo_Valley',
+    stage_image: './images/stages/gerudo_valley.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Golden Plains',
+    dlc: false,
+    universe: universes.mario,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Golden_Plains',
+    stage_image: './images/stages/golden_plains.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Green Hill Zone',
+    dlc: false,
+    universe: universes.sonic,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki: 'https://www.ssbwiki.com/Green_Hill_Zone',
+    stage_image: './images/stages/green_hill_zone.png',
+    past_smash_games: ['Smash Bros. Brawl']
+  },
+  {
+    name: 'The Great Cave Offensive',
+    dlc: false,
+    universe: universes.kirby,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki: 'https://www.ssbwiki.com/The_Great_Cave_Offensive',
+    stage_image: './images/stages/the_great_cave_offensive.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Halberd',
+    dlc: false,
+    universe: universes.kirby,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Halberd',
+    stage_image: './images/stages/halberd.png',
+    past_smash_games: ['Smash Bros. Brawl']
+  },
+  {
+    name: 'Hyrule Castle',
+    dlc: true,
+    universe: universes.legend_of_zelda,
+    wii_u: true,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Hyrule_Castle',
+    stage_image: './images/stages/hyrule_castle.png',
+    past_smash_games: ['Smash Bros. (64)']
+  },
+  {
+    name: 'Jungle Hijinxs',
+    dlc: false,
+    universe: universes.donkey_kong,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Jungle_Hijinxs',
+    stage_image: './images/stages/jungle_hijinx.jpg',
+    past_smash_games: []
+  },
+  {
+    name: 'Jungle Japes',
+    dlc: false,
+    universe: universes.donkey_kong,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Jungle_Japes',
+    stage_image: './images/stages/jungle_japes.png',
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee']
+  },
+  {
+    name: 'Kalos Pokemon League',
+    dlc: false,
+    universe: universes.pokemon,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Kalos_Pok%C3%A9mon_League',
+    stage_image: './images/stages/kalos_pokemon_league',
+    past_smash_games: []
+  },
+  {
+    name: 'Kongo Jungle',
+    dlc: false,
+    universe: universes.donkey_kong,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Kongo_Jungle_(SSB)',
+    stage_image: './images/stages/kongo_jungle.png',
+    past_smash_games: ['Smash Bros. Melee', 'Smash Bros. (64)']
+  },
+  {
+    name: 'Living Room',
+    dlc: false,
+    universe: universes.nintendogs,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Living_Room',
+    stage_image: './images/stages/living_room.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Luigi\'s Mansion', 
+    dlc: false,
+    universe: universes.mario,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Luigi%27s_Mansion',
+    stage_image: './images/stages/luigis_mansion.png',
+    past_smash_games: ['Smash Bros. Brawl']
+  },
+  {
+    name: 'Lylat Cruise',
+    dlc: false,
+    universe: universes.star_fox,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Lylat_Cruise',
+    stage_image: './images/stages/lylat_cruise.jpg',
+    past_smash_games: ['Smash Bros. Brawl']
+  },
+  {
+    name: 'Magicant',
+    dlc: false,
+    universe: universes.earthbound,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Magicant',
+    stage_image: './images/stages/magicant.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Mario Circuit Brawl',
+    dlc: false,
+    universe: universes.mario,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Mario_Circuit_(SSBB)',
+    stage_image: './images/stages/mario_circuit.png',
+    past_smash_games: ['Smash Bros. Brawl']
+  },
+  {
+    name: 'Mario Circuit',
+    dlc: false,
+    universe: universes.mario,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Mario_Circuit_(SSB4)',
+    stage_image: './images/stages/mario_circuit_2.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Mario Galaxy',
+    dlc: false,
+    universe: universes.mario,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Mario_Galaxy',
+    stage_image: './images/stages/mario_galaxy.jpg',
+    past_smash_games: []
+  },
+  {
+    name: 'Midgar',
+    dlc: true,
+    universe: universes.final_fantasy,
+    wii_u: true,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Midgar',
+    stage_image: './images/stages/midgar.jpg',
+    past_smash_games: []
+  },
+  {
+    name: 'Miiverse',
+    dlc: true,
+    universe: universes.miiverse,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Miiverse',
+    stage_image: './images/stages/miiverse.jpg',
+    past_smash_games: []
+  },
+  {
+    name: 'Mushroomy Kingdom',
+    dlc: false,
+    universe: universes.mario,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Mushroomy_Kingdom',
+    stage_image: './images/stages/mushroomy_kingdom.png',
+    past_smash_games: ['Smash Bros. Brawl']
+  },
+  {
+    name: 'Mushroomy Kingdom U',
+    dlc: false,
+    universe: universes.mario,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Mushroom_Kingdom_U',
+    stage_image: './images/stages/mushroom_kingdom_u.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Mute City SNES', 
+    dlc: false,
+    universe: universes.f_zero,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Mute_City_(SSB4)',
+    stage_image: './images/stages/mute_city.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Norfair',
+    dlc: false,
+    universe: universes.metroid,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Norfair',
+    stage_image: './images/stages/norfair.png',
+    past_smash_games: ['Smash Bros. Brawl']
+  },
+  {
+    name: 'Onett',
+    dlc: false,
+    universe: universes.earthbound,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki: 'https://www.ssbwiki.com/Onett',
+    stage_image: './images/stages/onett.png',
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee'],
+  },
+  {
+    name: 'Orbital Gate Assault',
+    dlc: false,
+    universe: universes.star_fox,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Orbital_Gate_Assault',
+    stage_image: './images/stages/orbital_gate_assault.jpg',
+    past_smash_games: []
+  },
+  {
+    name: 'Pac-Land',
+    dlc: false,
+    universe: universes.pac_man,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Pac-Land',
+    stage_image: './images/stages/pac_land.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Pac-Maze',
+    dlc: false,
+    universe: universes.pac_man,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Pac-Maze',
+    stage_image: './images/stages/pac_maze.jpg',
+    past_smash_games: []
+  },
+  {
+    name: 'Palutena\'s Temple',
+    dlc: false,
+    universe: universes.kid_icarus,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Palutena%27s_Temple',
+    stage_image: './images/stages/palutenas_temple.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Paper Mario',
+    dlc: false,
+    universe: universes.mario,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Paper_Mario',
+    stage_image: './images/stages/paper_mario.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Peach\'s Castle',
+    dlc: true,
+    universe: universes.mario,
+    wii_u: true,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Peach%27s_Castle',
+    stage_image: './images/stages/peachs_castle.png',
+    past_smash_games: ['Smash Bros. (64)']
+  },
+  {
+    name: 'Pictochat 2',
+    dlc: false,
+    universe: universes.nintendo_ds,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/PictoChat_2',
+    stage_image: './images/stages/pictochat_2.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Pilotwings',
+    dlc: false,
+    universe: universes.pilotwings,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Pilotwings',
+    stage_image: './images/stages/pilotwings.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Pirate Ship', 
+    dlc: true,
+    universe: universes.legend_of_zelda,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Pirate_Ship',
+    stage_image: './images/stages/pirate_ship.png',
+    past_smash_games: ['Smash Bros. Brawl']
+  },
+  {
+    name: 'Pokemon Stadium 2',
+    dlc: false,
+    universe: universes.pokemon,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Pok%C3%A9mon_Stadium_2',
+    stage_image: './images/stages/pokemon_stadium_2.png',
+    past_smash_games: ['Smash Bros. Brawl']
+  },
+  {
+    name: 'Port Town Aero Dive',
+    dlc: false,
+    universe: universes.f_zero,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Port_Town_Aero_Dive',
+    stage_image: './images/stages/port_town_aero_drive.png',
+    past_smash_games: ['Smash Bros. Brawl']
+  },
+  {
+    name: 'Prism Tower',
+    dlc: false,
+    universe: universes.pokemon,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Prism_Tower',
+    stage_image: './images/stages/prism_tower.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Pyrosphere',
+    dlc: false,
+    universe: universes.metroid,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Pyrosphere',
+    stage_image: './images/stages/pyrosphere.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Rainbox Road',
+    dlc: false,
+    universe: universes.mario,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Rainbow_Road',
+    stage_image: './images/stages/rainbow_road.jpg',
+    past_smash_games: []
+  },
+  {
+    name: 'Reset Bomb Forest',
+    dlc: false,
+    universe: universes.kid_icarus,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Reset_Bomb_Forest',
+    stage_image: './images/stages/reset_bomb_forest.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Skyloft',
+    dlc: false,
+    universe: universes.legend_of_zelda,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Skyloft',
+    stage_image: './images/stages/skyloft.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Skyworld',
+    dlc: false,
+    universe: universes.kid_icarus,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Skyworld',
+    stage_image: './images/stages/skyworld.png',
+    past_smash_games: ['Smash Bros. Brawl']
+  },
+  {
+    name: 'Smashville',
+    dlc: false,
+    universe: universes.animal_crossing,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Smashville',
+    stage_image: './images/stages/smashville.png',
+    past_smash_games: ['Smash Bros. Brawl']
+  },
+  {
+    name: 'Spirit Train',
+    dlc: false,
+    universe: universes.legend_of_zelda,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Spirit_train',
+    stage_image: './images/stages/spirit_train.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Super Mario Maker',
+    dlc: true,
+    universe: universes.mario,
+    wii_u: true,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Super_Mario_Maker',
+    stage_image: './images/stages/super_mario_maker.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Suzaku Castle',
+    dlc: true,
+    universe: universes.street_fighter,
+    wii_u: true,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Suzaku_Castle',
+    stage_image: './images/stages/suzaku_castle.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Temple',
+    dlc: false,
+    universe: universes.legend_of_zelda,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Temple',
+    stage_image: './images/stages/temple.png',
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee']
+  },
+  {
+    name: 'Tomodachi Life',
+    dlc: false,
+    universe: universes.tomodachi,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Tomodachi_Life',
+    stage_image: './images/stages/tomodachi_life.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Tortimer Island',
+    dlc: false,
+    universe: universes.animal_crossing,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Tortimer_Island',
+    stage_image: './images/stages/tortimer_island.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Town and City',
+    dlc: false,
+    universe: universes.animal_crossing,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Town_and_City',
+    stage_image: './images/stages/town_and_city.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Umbra Clock Tower',
+    dlc: true,
+    universe: universes.bayonetta,
+    wii_u: true,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Umbra_Clock_Tower',
+    stage_image: './images/stages/umbra_clock_tower.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Unova Pokemon League',
+    dlc: false,
+    universe: universes.pokemon,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Unova_Pok%C3%A9mon_League',
+    stage_image: './images/stages/unova_pokemon_league.png',
+    past_smash_games: []
+  },
+  {
+    name: 'WarioWare Inc.',
+    dlc: false,
+    universe: universes.wario,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/WarioWare,_Inc.',
+    stage_image: './images/stages/warioware_inc.png',
+    past_smash_games: ['Smash Bros. Brawl']
+  },
+  {
+    name: 'Wii Fit Studio',
+    dlc: false,
+    universe: universes.wii_fit,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Wii_Fit_Studio',
+    stage_image: './images/stages/wii_fit_studio.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Wily Castle',
+    dlc: false,
+    universe: universes.mega_man,
+    wii_u: true,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Wily_Castle',
+    stage_image: './images/stages/wily_castle.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Windy Hill Zone',
+    dlc: false,
+    universe: universes.sonic,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Windy_Hill_Zone',
+    stage_image: './images/stages/windy_hill_zone.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Wooly World',
+    dlc: false,
+    universe: universes.yoshi,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Woolly_World',
+    stage_image: './images/stages/wooly_world.jpg',
+    past_smash_games: []
+  },
+  {
+    name: 'Wrecking Crew',
+    dlc: false,
+    universe: universes.wrecking_crew,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Wrecking_Crew',
+    stage_image: './images/stages/wrecking_crew.png',
+    past_smash_games: []
+  },
+  {
+    name: 'Wuhu Island',
+    dlc: false,
+    universe: universes.wii_sports,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Wuhu_Island',
+    stage_image: './images/stages/wuhu_island.png',
+    past_smash_games: []
+  },
+  {
+    name:  'Yoshi\'s Island (Melee)',
+    dlc: false,
+    universe: universes.yoshi,
+    wii_u: true,
+    nintendo_3ds: false,
+    smash_wiki:'https://www.ssbwiki.com/Yoshi%27s_Island_(SSBM)',
+    stage_image: './images/stages/yoshis_island_melee.png',
+    past_smash_games: ['Smash Bros. Brawl', 'Smash Bros. Melee']
+  },
+  {
+    name: 'Yoshi\'s Island (Brawl)',
+    dlc: false,
+    universe: universes.yoshi,
+    wii_u: false,
+    nintendo_3ds: true,
+    smash_wiki:'https://www.ssbwiki.com/Yoshi%27s_Island_(SSBB)',
+    stage_image: './images/stages/yoshis_island_brawl.png',
+    past_smash_games: ['Smash Bros. Brawl']
+  },
+];
+
+const universes = {
+  animal_crossing: {
+    name: 'Animal Crossing',
+    icon: './images/universe_icons/gray_icon_animal_crossing.svg'
+  },
+  balloon_fight: {
+    name: 'Balloon Fight',
+    icon: './images/universe_icons/gray_icon_balloon_fight.svg'
+  },
+  bayonetta: {
+    name: 'Bayonetta',
+    icon: './images/universe_icons/gray_icon_bayonetta.svg'
+  },
+  castlevania: {
+    name: 'Castlevania',
+    icon: './images/universe_icons/gray_icon_castlevania.svg'
+  },
+  custom_stage: {
+    name: 'Custom Stage',
+    icon: './images/universe_icons/gray_icon_custom_stage.svg'
+  },
+  donkey_kong: {
+    name: 'Donkey Kong',
+    icon: './images/universe_icons/gray_icon_donkey_kong.svg'
+  },
+  duck_hunt: {
+    name: 'Duck Hunt',
+    icon: './images/universe_icons/gray_icon_duck_hunt.svg'
+  },
+  earthbound: {
+    name: 'EarthBound',
+    icon: './images/universe_icons/gray_icon_earthbound.svg'
+  },
+  electroplankton: {
+    name: 'Electroplankton',
+    icon: './images/universe_icons/gray_icon_electro_plankton.svg'
+  },
+  f_zero: {
+    name: 'F-Zero',
+    icon: './images/universe_icons/gray_icon_f_zero.svg'
+  },
+  final_fantasy: {
+    name: 'Final Fantasy',
+    icon: './images/universe_icons/gray_icon_final_fantasy.svg'
+  },
+  find_mii: {
+    name: 'Find Mii',
+    icon: './images/universe_icons/gray_icon_find_me.svg'
+  },
+  fire_emblem: {
+    name: 'Fire Emblem',
+    icon: './images/universe_icons/gray_icon_fire_emblem.svg'
+  },
+  ice_climbers: {
+    name: 'Ice Climbers',
+    icon: './images/universe_icons/gray_icon_ice_climber.svg'
+  },
+  kid_icarus: {
+    name: 'Kid Icarus',
+    icon: './images/universe_icons/gray_icon_kid_icarus.svg'
+  },
+  kirby: {
+    name: 'Kirby',
+    icon: './images/universe_icons/gray_icon_kirby.svg'
+  },
+  mario: {
+    name: 'Mario',
+    icon: './images/universe_icons/gray_icon_mario.svg'
+  },
+  mega_man: {
+    name: 'Mega Man',
+    icon: './images/universe_icons/gray_icon_mega_man.svg'
+  },
+  metal_gear: {
+    name: 'Metal Gear',
+    icon: './images/universe_icons/gray_icon_metal_gear.svg'
+  },
+  metal_mario: {
+    name: 'Metal Mario',
+    icon: './images/universe_icons/gray_icon_metal_mario.svg'
+  },
+  metroid: {
+    name: 'Metroid',
+    icon: './images/universe_icons/gray_icon_metroid.svg'
+  },
+  miiverse: {
+    name: 'Miiverse',
+    icon: './images/universe_icons/gray_icon_miiverse.svg'
+  },
+  game_and_watch: {
+    name: 'Game & Watch',
+    icon: './images/universe_icons/gray_icon_game_and_watch.svg'
+  },
+  nintendo_ds: {
+    name: 'Nintendo DS',
+    icon: './images/universe_icons/gray_icon_nintendo_ds.svg'
+  },
+  nintendogs: {
+    name: 'Nintendogs',
+    icon: './images/universe_icons/gray_icon_nintendogs.svg'
+  },
+  pac_man: {
+    name: 'Pac-Man',
+    icon: './images/universe_icons/gray_icon_pacman.svg'
+  },
+  pikmin: {
+    name: 'Pikmin',
+    icon: './images/universe_icons/gray_icon_pikmin.svg'
+  },
+  pilotwings: {
+    name: 'Pilotwings',
+    icon: './images/universe_icons/gray_icon_pilotwings.svg'
+  },
+  pokemon: {
+    name: 'Pok&#233mon',
+    icon: './images/universe_icons/gray_icon_pokemon.svg'
+  },
+  punch_out: {
+    name: 'Punch Out!!',
+    icon: './images/universe_icons/gray_icon_punchout.svg'
+  },
+  rob: {
+    name: 'R.O.B.',
+    icon: './images/universe_icons/gray_icon_rob.svg'
+  },
+  smash_bros: {
+    name: 'Super Smash Bros.',
+    icon: './images/universe_icons/gray_icon_smash_bros.svg'
+  },
+  sonic: {
+    name: 'Sonic',
+    icon: './images/universe_icons/gray_icon_sonic.svg'
+  },
+  splatoon: {
+    name: 'Splatoon',
+    icon: './images/universe_icons/gray_icon_splatoon.svg'
+  },
+  star_fox: {
+    name: 'Star Fox',
+    icon: './images/universe_icons/gray_icon_star_fox.svg'
+  },
+  street_fighter: {
+    name: 'Street Fighter',
+    icon: './images/universe_icons/gray_icon_street_fighter.svg'
+  },
+  subspace: {
+    name: 'Subspace',
+    icon: './images/universe_icons/gray_icon_subspace.svg'
+  },
+  tomodachi: {
+    name: 'Tomodachi',
+    icon: './images/universe_icons/gray_icon_tomodachi.svg'
+  },
+  unknown: {
+    name: 'Unknown',
+    icon: './images/universe_icons/gray_icon_unknown.svg'
+  },
+  wario: {
+    name: 'Wario',
+    icon: './images/universe_icons/gray_icon_wario.svg'
+  },
+  wii_fit: {
+    name: 'Wii Fit',
+    icon: './images/universe_icons/gray_icon_wii_fit.svg'
+  },
+  wii_sports: {
+    name: 'Wii Sports',
+    icon: './images/universe_icons/gray_icon_wii_sports.svg'
+  },
+  wrecking_crew: {
+    name: 'Wrecking Crew',
+    icon: './images/universe_icons/gray_icon_wrecking_crew.svg'
+  },
+  xenoblade: {
+    name: 'Xenoblade',
+    icon: './images/universe_icons/gray_icon_xenoblade.svg'
+  },
+  yoshi: {
+    name: 'Yoshi',
+    icon: './images/universe_icons/gray_icon_yoshi.svg'
+  },
+  legend_of_zelda: {
+    name: 'The Legend of Zelda',
+    icon: './images/universe_icons/gray_icon_zelda.svg'
+  },
+}
+
+module.exports = characters;
+module.exports = stages;
+module.exports = universes;


### PR DESCRIPTION
Currently there is no all-in-one site for getting need-to-know information about all of the smash brothers characters and stages.  In order to find everything I want to know I have to traverse at least 5 sites.  

-Reddit for condensed pros and cons of each character
-Smash wiki for moveset and general character info
-Another site for speed, weight, and jump stats (with a shitty ui I might add)
-smash world for characters' performance and rankings in the pro circuit
-the actual smash bros site if I want a pretty ui with good pics of each character

There is nowhere that compiles all this info on the web. I want to create site that solves this issue and includes stage info as well. Not only will the site have player cards and stage cards, but it'll allow you to sort and filter them based on original game franchise, speed, weight, pro-ranking, most powerful move, and more.  

This will be the quintessential site for SmashBros nerds and will be easily updatable when Smash Ultimate is released in December. 

I have also gathered over 200 compressed svgs, images, and icons for every character, stage, and universe and linked them to their respective objects so they can be dynamically added to character cards. 