### PR TITLE
Buffy the Vampire Slayer and Angel Television Shows

### DIFF
--- a/datasets/Buffy.js
+++ b/datasets/Buffy.js
@@ -1,4 +1,4 @@
-const tvShow = {  
+const tvShow ={  
    "name":"Buffy the Vampire Slayer",
    "url":"https://www.imdb.com/title/tt0118276/",
    "language":"English",
@@ -846,5 +846,7 @@ const spinOff = {
 };
 
 
-module.exports = tvShow;
-module.exports = spinOff;
+module.exports = {
+  tvShow, 
+  spinoff
+};

--- a/datasets/Buffy.js
+++ b/datasets/Buffy.js
@@ -1,0 +1,850 @@
+const tvShow = {  
+   "name":"Buffy the Vampire Slayer",
+   "url":"https://www.imdb.com/title/tt0118276/",
+   "language":"English",
+   "genre":[  
+      "Action",
+      "Drama",
+      "Fantasy"
+   ],
+   "premiered":"03-10-1997",
+   "seasons":7,
+   "rating":{  
+      "average":8.2
+   },
+   "creator":"Joss Whedon",
+   "summary":"A young woman, destined to slay vampires, demons and other infernal creatures, deals with her life fighting evil, with the help of her friends.",
+   "spinoff":"Angel",
+   "episodes":[  
+      {  
+         "name":"Welcome to the Hellmouth",
+         "season":1,
+         "number":1,
+         "airdate":-2004,
+         "starring":[  
+            "Buffy",
+            "Xander",
+            "Willow",
+            "Cordelia",
+            "Giles",
+            "Angel",
+            "Darla",
+            "The Master"
+         ],
+         "weapons":[  
+            "Cross Necklace",
+            "Slayer Handbook",
+            "Stake"
+         ],
+         "deathcount":2,
+         "rating":{  
+            "average":8.2
+         },
+         "network":"The WB",
+         "writer":"Joss Whedon"
+      },
+      {  
+         "name":"The Harvest",
+         "season":1,
+         "number":2,
+         "airdate":-2004,
+         "starring":[  
+            "Buffy",
+            "Xander",
+            "Willow",
+            "Cordelia",
+            "Giles",
+            "Angel",
+            "Darla",
+            "The Master",
+            "Joyce",
+            "Principal Flutie",
+            "Harmony"
+         ],
+         "weapons":[  
+            "Cross Necklace",
+            "Holy Water",
+            "Stake"
+         ],
+         "deathcount":7,
+         "rating":{  
+            "average":8
+         },
+         "network":"The WB",
+         "writer":"Joss Whedon"
+      },
+      {  
+         "name":"Witch",
+         "season":1,
+         "number":3,
+         "airdate":-2011,
+         "starring":[  
+            "Buffy",
+            "Xander",
+            "Willow",
+            "Cordelia",
+            "Giles",
+            "Joyce",
+            "Amy",
+            "Catherine"
+         ],
+         "weapons":[  
+            "Fire Axe",
+            "Giles's Citroen",
+            "Stake"
+         ],
+         "deathcount":0,
+         "rating":{  
+            "average":7.8
+         },
+         "network":"The WB",
+         "writer":"Dana Reston"
+      },
+      {  
+         "name":"Teacher's Pet",
+         "season":1,
+         "number":4,
+         "airdate":-2018,
+         "starring":[  
+            "Buffy",
+            "Xander",
+            "Willow",
+            "Cordelia",
+            "Giles",
+            "Angel",
+            "Principal Flutie",
+            "Ms. French"
+         ],
+         "weapons":[  
+            "Stake",
+            "Machete"
+         ],
+         "deathcount":4,
+         "rating":{  
+            "average":7.1
+         },
+         "network":"The WB",
+         "writer":"David Greenwalt"
+      },
+      {  
+         "name":"Never Kill a Boy on the First Date",
+         "season":1,
+         "number":5,
+         "airdate":-2025,
+         "starring":[  
+            "Buffy",
+            "Xander",
+            "Willow",
+            "Cordelia",
+            "Giles",
+            "Angel",
+            "The Master",
+            "Owen"
+         ],
+         "weapons":[  
+            "Stake",
+            "Sunndaydale Press"
+         ],
+         "deathcount":6,
+         "rating":{  
+            "average":7.6
+         },
+         "network":"The WB",
+         "writer":"Rob Des Hotel"
+      },
+      {  
+         "name":"The Pack",
+         "season":1,
+         "number":6,
+         "airdate":-2000,
+         "starring":[  
+            "Buffy",
+            "Xander",
+            "Willow",
+            "Cordelia",
+            "Giles",
+            "Principal Flutie"
+         ],
+         "weapons":[  
+            "Knife",
+            "Desk"
+         ],
+         "deathcount":3,
+         "rating":{  
+            "average":7.6
+         },
+         "network":"The WB",
+         "writer":"Matt Kiene"
+      },
+      {  
+         "name":"Angel",
+         "season":1,
+         "number":7,
+         "airdate":-2007,
+         "starring":[  
+            "Buffy",
+            "Xander",
+            "Willow",
+            "Cordelia",
+            "Giles",
+            "The Master",
+            "Angel",
+            "Joyce",
+            "Darla"
+         ],
+         "weapons":[  
+            "Cross Necklace",
+            "Crossbow",
+            "Pistol",
+            "Quarterstaff",
+            "Stake"
+         ],
+         "deathcount":4,
+         "rating":{  
+            "average":8.6
+         },
+         "network":"The WB",
+         "writer":"David Greenwalt"
+      },
+      {  
+         "name":"I, Robot... You, Jane",
+         "season":1,
+         "number":8,
+         "airdate":-2021,
+         "starring":[  
+            "Buffy",
+            "Xander",
+            "Willow",
+            "Cordelia",
+            "Giles",
+            "Jenny"
+         ],
+         "weapons":[  
+            "Tome of Moloch"
+         ],
+         "deathcount":4,
+         "rating":{  
+            "average":6.9
+         },
+         "network":"The WB",
+         "writer":"Ashley Gable"
+      },
+      {  
+         "name":"The Puppet Show",
+         "season":1,
+         "number":9,
+         "airdate":-1997,
+         "starring":[  
+            "Buffy",
+            "Xander",
+            "Willow",
+            "Cordelia",
+            "Giles",
+            "Joyce",
+            "Principal Snyder"
+         ],
+         "weapons":[  
+
+         ],
+         "deathcount":4,
+         "rating":{  
+            "average":7.8
+         },
+         "network":"The WB",
+         "writer":"Rob Des Hotel"
+      },
+      {  
+         "name":"Nightmares",
+         "season":1,
+         "number":10,
+         "airdate":-2004,
+         "starring":[  
+            "Buffy",
+            "Xander",
+            "Willow",
+            "Cordelia",
+            "Giles",
+            "Joyce",
+            "The Master"
+         ],
+         "weapons":[  
+            "Cross Necklace",
+            "Sunnydale Press"
+         ],
+         "deathcount":2,
+         "rating":{  
+            "average":8.4
+         },
+         "network":"The WB",
+         "writer":"Joss Whedon"
+      },
+      {  
+         "name":"Out of Mind, Out of Sight",
+         "season":1,
+         "number":11,
+         "airdate":-2011,
+         "starring":[  
+            "Buffy",
+            "Xander",
+            "Willow",
+            "Cordelia",
+            "Giles",
+            "Angel",
+            "Principal Snyder"
+         ],
+         "weapons":[  
+
+         ],
+         "deathcount":0,
+         "rating":{  
+            "average":7.9
+         },
+         "network":"The WB",
+         "writer":"Joss Whedon"
+      },
+      {  
+         "name":"Prophecy Girl",
+         "season":1,
+         "number":12,
+         "airdate":-1993,
+         "starring":[  
+            "Buffy",
+            "Xander",
+            "Willow",
+            "Cordelia",
+            "Giles",
+            "Angel",
+            "The Master",
+            "Joyce",
+            "Jenny"
+         ],
+         "weapons":[  
+            "Cross Necklace",
+            "Crossbow"
+         ],
+         "deathcount":11,
+         "rating":{  
+            "average":8.9
+         },
+         "network":"The WB",
+         "writer":"Joss Whedon"
+      },
+      {  
+         "name":"When She Was Bad",
+         "season":2,
+         "number":1,
+         "airdate":-2003,
+         "starring":[  
+            "Buffy",
+            "Xander",
+            "Willow",
+            "Cordelia",
+            "Giles",
+            "Angel",
+            "Joyce",
+            "Principal Snyder",
+            "Jenny"
+         ],
+         "weapons":[  
+            "Cross Necklace",
+            "Holy Water",
+            "Stake",
+            "Jeep"
+         ],
+         "deathcount":7,
+         "rating":{  
+            "average":8.3
+         },
+         "network":"The WB",
+         "writer":"Joss Whedon"
+      },
+      {  
+         "name":"Some Assembly Required",
+         "season":2,
+         "number":2,
+         "airdate":-2010,
+         "starring":[  
+            "Buffy",
+            "Xander",
+            "Willow",
+            "Cordelia",
+            "Giles",
+            "Angel",
+            "Jenny"
+         ],
+         "weapons":[  
+            "Cross Necklace",
+            "QUEEN C",
+            "Stake"
+         ],
+         "deathcount":5,
+         "rating":{  
+            "average":7.2
+         },
+         "network":"The WB",
+         "writer":"Ty King"
+      },
+      {  
+         "name":"School Hard",
+         "season":2,
+         "number":3,
+         "airdate":-2017,
+         "starring":[  
+            "Buffy",
+            "Xander",
+            "Willow",
+            "Cordelia",
+            "Giles",
+            "Angel",
+            "Jenny",
+            "Joyce",
+            "Spike",
+            "Principal Snyder",
+            "Drusilla"
+         ],
+         "weapons":[  
+            "Axe",
+            "Jeep",
+            "Stake"
+         ],
+         "deathcount":9,
+         "rating":{  
+            "average":8.9
+         },
+         "network":"The WB",
+         "writer":"David Greenwalt"
+      },
+      {  
+         "name":"Inca Mummy Girl",
+         "season":2,
+         "number":4,
+         "airdate":-1993,
+         "starring":[  
+            "Buffy",
+            "Xander",
+            "Willow",
+            "Cordelia",
+            "Giles",
+            "Angel",
+            "Joyce",
+            "Inca Mummy",
+            "Oz"
+         ],
+         "weapons":[  
+            "Inca Sacred Seal",
+            "Oz's Zebra-Striped Van"
+         ],
+         "deathcount":9,
+         "rating":{  
+            "average":7.4
+         },
+         "network":"The WB",
+         "writer":"Matt Kiene"
+      },
+      {  
+         "name":"Reptile Boy",
+         "season":2,
+         "number":5,
+         "airdate":-2000,
+         "starring":[  
+            "Buffy",
+            "Xander",
+            "Willow",
+            "Cordelia",
+            "Giles",
+            "Angel",
+            "Jonathan"
+         ],
+         "weapons":[  
+            "QUEEN C",
+            "Sunndaydale Press",
+            "Sword"
+         ],
+         "deathcount":4,
+         "rating":{  
+            "average":7.3
+         },
+         "network":"The WB",
+         "writer":"David Greenwalt"
+      },
+      {  
+         "name":"Halloween",
+         "season":2,
+         "number":6,
+         "airdate":-2014,
+         "starring":[  
+            "Buffy",
+            "Xander",
+            "Willow",
+            "Cordelia",
+            "Giles",
+            "Angel",
+            "Oz",
+            "Spike",
+            "Drusilla",
+            "Principal Snyder",
+            "Ethan"
+         ],
+         "weapons":[  
+            "Gun",
+            "Janus' Statue",
+            "Sword",
+            "Oz's Zebra-Striped Van"
+         ],
+         "deathcount":2,
+         "rating":{  
+            "average":8.9
+         },
+         "network":"The WB",
+         "writer":"Carl Ellsworth"
+      },
+      {  
+         "name":"Lie to Me",
+         "season":2,
+         "number":7,
+         "airdate":-1989,
+         "starring":[  
+            "Buffy",
+            "Xander",
+            "Willow",
+            "Cordelia",
+            "Giles",
+            "Angel",
+            "Jenny",
+            "Drusilla"
+         ],
+         "weapons":[  
+            "Du Lac Manuscript",
+            "Stake"
+         ],
+         "deathcount":4,
+         "rating":{  
+            "average":8.5
+         },
+         "network":"The WB",
+         "writer":"Joss Whedon"
+      },
+      {  
+         "name":"The Dark Age",
+         "season":2,
+         "number":8,
+         "airdate":-1996,
+         "starring":[  
+            "Buffy",
+            "Xander",
+            "Willow",
+            "Cordelia",
+            "Giles",
+            "Angel",
+            "Jenny",
+            "Ethan"
+         ],
+         "weapons":[  
+            "Mark of Eyghon"
+         ],
+         "deathcount":7,
+         "rating":{  
+            "average":8
+         },
+         "network":"The WB",
+         "writer":"Dean Batali"
+      },
+      {  
+         "name":"What's My Line (Part One)",
+         "season":2,
+         "number":9,
+         "airdate":-2003,
+         "starring":[  
+            "Buffy",
+            "Xander",
+            "Willow",
+            "Cordelia",
+            "Giles",
+            "Angel",
+            "Oz",
+            "Spike",
+            "Kendra",
+            "Drusilla",
+            "Principal Snyder"
+         ],
+         "weapons":[  
+            "Cross Necklace",
+            "Du Lac Cross",
+            "Mr. Gordo",
+            "QUEEN C",
+            "Watchers Diaries"
+         ],
+         "deathcount":3,
+         "rating":{  
+            "average":8.5
+         },
+         "network":"The WB",
+         "writer":"Howard Gordon"
+      },
+      {  
+         "name":"What's My Line (Part Two)",
+         "season":2,
+         "number":10,
+         "airdate":-2010,
+         "starring":[  
+            "Buffy",
+            "Xander",
+            "Willow",
+            "Cordelia",
+            "Giles",
+            "Angel",
+            "Oz",
+            "Spike",
+            "Kendra",
+            "Drusilla"
+         ],
+         "weapons":[  
+            "Cross Necklace",
+            "Slayer Handbook",
+            "QUEEN C",
+            "Stake"
+         ],
+         "deathcount":4,
+         "rating":{  
+            "average":8.7
+         },
+         "network":"The WB",
+         "writer":"Marti Noxon"
+      }
+   ]
+};
+
+const spinOff = {  
+   "name":"Angel",
+   "url":"https://www.imdb.com/title/tt0162065/",
+   "language":"English",
+   "genre":[  
+      "Action",
+      "Drama",
+      "Fantasy"
+   ],
+   "premiered":"10-05-1999",
+   "seasons":5,
+   "rating":{  
+      "average":8
+   },
+   "creator":"Joss Whedon",
+   "summary":"The vampire Angel, cursed with a soul, moves to Los Angeles and aids people with supernatural-related problems while questing for his own redemption.",
+   "episodes":[  
+      {  
+         "name":"City Of",
+         "season":1,
+         "number":1,
+         "airdate":-1994,
+         "starring":[  
+            "Angel",
+            "Cordelia",
+            "Doyle",
+            "Lindsey",
+            "Tina"
+         ],
+         "weapons":[  
+
+         ],
+         "deathcount":7,
+         "rating":{  
+            "average":8.7
+         },
+         "network":"The WB",
+         "writer":"Joss Whedon"
+      },
+      {  
+         "name":"Lonely Heart",
+         "season":1,
+         "number":2,
+         "airdate":-2001,
+         "starring":[  
+            "Angel",
+            "Cordelia",
+            "Doyle",
+            "Kate"
+         ],
+         "weapons":[  
+
+         ],
+         "deathcount":6,
+         "rating":{  
+            "average":8.1
+         },
+         "network":"The WB",
+         "writer":"David Fury"
+      },
+      {  
+         "name":"In The Dark",
+         "season":1,
+         "number":3,
+         "airdate":-2008,
+         "starring":[  
+            "Angel",
+            "Cordelia",
+            "Doyle",
+            "Oz",
+            "Spike"
+         ],
+         "weapons":[  
+
+         ],
+         "deathcount":1,
+         "rating":{  
+            "average":8.7
+         },
+         "network":"The WB",
+         "writer":"Douglas Petrie"
+      },
+      {  
+         "name":"I Fall to Pieces",
+         "season":1,
+         "number":4,
+         "airdate":-2015,
+         "starring":[  
+            "Angel",
+            "Cordelia",
+            "Doyle",
+            "Kate"
+         ],
+         "weapons":[  
+
+         ],
+         "deathcount":2,
+         "rating":{  
+            "average":7.2
+         },
+         "network":"The WB",
+         "writer":"David Greenwalt"
+      },
+      {  
+         "name":"Rm w/a Vu",
+         "season":1,
+         "number":5,
+         "airdate":-1990,
+         "starring":[  
+            "Angel",
+            "Cordelia",
+            "Doyle",
+            "Kate",
+            "Mrs. Pearson"
+         ],
+         "weapons":[  
+
+         ],
+         "deathcount":5,
+         "rating":{  
+            "average":8.4
+         },
+         "network":"The WB",
+         "writer":"Jane Espenson"
+      },
+      {  
+         "name":"Sense & Sensitivity",
+         "season":1,
+         "number":6,
+         "airdate":-1997,
+         "starring":[  
+            "Angel",
+            "Cordelia",
+            "Doyle",
+            "Kate"
+         ],
+         "weapons":[  
+
+         ],
+         "deathcount":4,
+         "rating":{  
+            "average":7.8
+         },
+         "network":"The WB",
+         "writer":"Tim Minear"
+      },
+      {  
+         "name":"The Bachelor Party",
+         "season":1,
+         "number":7,
+         "airdate":-2004,
+         "starring":[  
+            "Angel",
+            "Cordelia",
+            "Doyle"
+         ],
+         "weapons":[  
+
+         ],
+         "deathcount":3,
+         "rating":{  
+            "average":7.5
+         },
+         "network":"The WB",
+         "writer":"Tracy Stern"
+      },
+      {  
+         "name":"I Will Remember You",
+         "season":1,
+         "number":8,
+         "airdate":-2011,
+         "starring":[  
+            "Angel",
+            "Cordelia",
+            "Doyle",
+            "Buffy"
+         ],
+         "weapons":[  
+
+         ],
+         "deathcount":3,
+         "rating":{  
+            "average":9.3
+         },
+         "network":"The WB",
+         "writer":"David Greenwalt"
+      },
+      {  
+         "name":"Hero",
+         "season":1,
+         "number":9,
+         "airdate":-2018,
+         "starring":[  
+            "Angel",
+            "Cordelia",
+            "Doyle"
+         ],
+         "weapons":[  
+
+         ],
+         "deathcount":4,
+         "rating":{  
+            "average":9
+         },
+         "network":"The WB",
+         "writer":"Tim Minear"
+      },
+      {  
+         "name":"Parting Gifts",
+         "season":1,
+         "number":10,
+         "airdate":-2001,
+         "starring":[  
+            "Angel",
+            "Cordelia",
+            "Doyle",
+            "Wesley"
+         ],
+         "weapons":[  
+
+         ],
+         "deathcount":3,
+         "rating":{  
+            "average":8.4
+         },
+         "network":"The WB",
+         "writer":"David Fury"
+      }
+   ]
+};
+
+
+module.exports = tvShow;
+module.exports = spinOff;


### PR DESCRIPTION
The application holds data for two television shows and their episodes. The first is "Buffy the Vampire Slayer" and the second is its spinoff show "Angel."
You will be able to search for episode by either: 
- episode name
- season 
- episode number
- airdate of the episode
- who starred in the episode
- what weapons were used in the episode
- what the death count for that episode was
- average rating for the episode
- the network the episode was on
- who wrote the episode
